### PR TITLE
Better support for traditional joysticks.

### DIFF
--- a/lib/cfclient/configs/input/Joystick.json
+++ b/lib/cfclient/configs/input/Joystick.json
@@ -1,0 +1,95 @@
+{
+  "inputconfig": {
+    "inputdevice": {
+      "updateperiod": 10, 
+      "springythrottle": false,
+      "name": "Joystick", 
+      "axis": [
+        {
+          "scale": -1.0, 
+          "type": "Input.AXIS", 
+          "id": 3, 
+          "key": "thrust", 
+          "name": "thrust"
+        }, 
+        {
+          "scale": 1.0, 
+          "type": "Input.AXIS", 
+          "id": 2, 
+          "key": "yaw", 
+          "name": "yaw"
+        }, 
+        {
+          "scale": 1.0, 
+          "type": "Input.AXIS", 
+          "id": 0, 
+          "key": "roll", 
+          "name": "roll"
+        }, 
+        {
+          "scale": -1.0, 
+          "type": "Input.AXIS", 
+          "id": 1, 
+          "key": "pitch", 
+          "name": "pitch"
+        }, 
+        {
+          "scale": 1.0,
+          "type": "Input.HAT",
+          "id": 0,
+          "key": "trim",
+          "name": "trim"
+        },
+        {
+          "scale": -1.0, 
+          "type": "Input.BUTTON", 
+          "id": 4, 
+          "key": "pitchcal", 
+          "name": "pitchNeg"
+        }, 
+        {
+          "scale": 1.0, 
+          "type": "Input.BUTTON", 
+          "id": 5, 
+          "key": "pitchcal", 
+          "name": "pitchPos"
+        }, 
+        {
+          "scale": 1.0, 
+          "type": "Input.BUTTON", 
+          "id": 1, 
+          "key": "estop", 
+          "name": "killswitch"
+        }, 
+        {
+          "scale": -1.0, 
+          "type": "Input.BUTTON", 
+          "id": 2, 
+          "key": "rollcal", 
+          "name": "rollNeg"
+        }, 
+        {
+          "scale": 1.0, 
+          "type": "Input.BUTTON", 
+          "id": 3, 
+          "key": "rollcal", 
+          "name": "rollPos"
+        }, 
+        {
+          "scale": 1.0, 
+          "type": "Input.BUTTON", 
+          "id": 0, 
+          "key": "althold", 
+          "name": "althold"
+        }, 
+        {
+          "scale": 1.0, 
+          "type": "Input.BUTTON", 
+          "id": 6, 
+          "key": "exit", 
+          "name": "exitapp"
+        }
+      ]
+    }
+  }
+}

--- a/lib/cfclient/utils/pygamereader.py
+++ b/lib/cfclient/utils/pygamereader.py
@@ -44,7 +44,7 @@ class PyGameReader():
     def start_input(self, deviceId, inputMap):
         """Initalize the reading and open the device with deviceId and set the mapping for axis/buttons using the
         inputMap"""
-        self.data = {"roll":0.0, "pitch":0.0, "yaw":0.0, "thrust":0.0, "pitchcal":0.0, "rollcal":0.0, "estop": False, "exit":False, "althold":False}
+        self.data = {"roll":0.0, "pitch":0.0, "yaw":0.0, "thrust":-1.0, "pitchcal":0.0, "rollcal":0.0, "estop": False, "exit":False, "althold":False}
         self.inputMap = inputMap
         self.j = pygame.joystick.Joystick(deviceId)
         self.j.init()
@@ -98,6 +98,18 @@ class PyGameReader():
             except Exception:
                 # Button not mapped, ignore..
                 pass            
+
+          if e.type == pygame.locals.JOYHATMOTION:
+            index = "Input.HAT-%d" % e.hat
+            try:
+                if (self.inputMap[index]["type"] == "Input.HAT"):
+                    key = self.inputMap[index]["key"]
+                    if (key == "trim"):
+                        self.data["rollcal"] = e.value[0] * self.inputMap[index]["scale"]
+                        self.data["pitchcal"] = e.value[1] * self.inputMap[index]["scale"]
+            except Exception:
+                # Hat not mapped, ignore..
+                pass
             
 
         return self.data


### PR DESCRIPTION
Some changes to make things work better with real joysticks.

The throttle lever on my joystick was way too sensitive because it was only using half the range. I added an option to the input config files to control how the thrust axis is handled. For gamepads it does the same as before (using only the + half of the axis) because they are spring loaded. But for joysticks with a dedicated throttle lever it makes more sense to use the full axis. Also, since it doesn't return to center, adjusting ASL is disabled in this mode.

I also added support for using the hat switch to control pitch and roll trim.
