### PR TITLE
Fixed setup.py on Linux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ except OSError:
 VERSION = output.strip()
 
 
+toplevel_data_files = ['README.md', 'LICENSE.txt']
 
 #Platform specific settings
 if sys.platform.startswith('win32'):
@@ -41,6 +42,8 @@ if sys.platform.startswith('win32'):
                                          "cfclient.ui.dialogs.*"],
                             "excludes": ["AppKit"],
                             "skip_archive": True}})
+
+    toplevel_data_files.append('SDL2.dll')
 else:
     setup_args=dict(
         scripts=['bin/cfclient', 'bin/cfheadless'])
@@ -58,7 +61,7 @@ setup_args=dict(name='cfclient',
                 'cfclient.utils', 'cfclient.ui.dialogs', 'cflib',
                 'cflib.bootloader', 'cflib.crazyflie', 'cflib.drivers',
                 'cflib.utils', 'cflib.crtp'],
-      data_files=[('', ['README.md', 'LICENSE.txt', 'SDL2.dll']),
+      data_files=[('', toplevel_data_files),
                   ('cfclient/ui',
                    glob.glob('lib/cfclient/ui/*.ui')),
                   ('cfclient/ui/tabs',


### PR DESCRIPTION
The `SDL2.dll` data file was being included even in Linux builds. This
commit fixes this by only including it on Windows.

This should probably be fixed soon, as it's contained in the `2014.12.1` tag.
