### PR TITLE
Make sure that the Thrust is at least zero for altitude hold.

### DIFF
--- a/lib/cfclient/utils/input.py
+++ b/lib/cfclient/utils/input.py
@@ -324,6 +324,11 @@ class JoystickReader:
 
             trimmed_roll = roll + self._trim_roll
             trimmed_pitch = pitch + self._trim_pitch
+
+            # Thrust might be <0 here, make sure it's not otherwise we'll get an error.
+            if thrust < 0:
+              thrust = 0
+
             self.input_updated.call(trimmed_roll, trimmed_pitch, yaw, thrust)
         except Exception:
             logger.warning("Exception while reading inputdevice: %s",


### PR DESCRIPTION
This prevents the following error from happening:

```
WARNING:cfclient.utils.input:Exception while reading inputdevice: Traceback (most recent call last):
  File "/Users/hoverbear/crazyflie/crazyflie-clients-python/lib/cfclient/utils/input.py", line 334, in read_input
    self.input_updated.call(trimmed_roll, trimmed_pitch, yaw, thrust)
  File "/Users/hoverbear/crazyflie/crazyflie-clients-python/lib/cflib/utils/callbacks.py", line 56, in call
    cb(*args)
  File "/Users/hoverbear/crazyflie/crazyflie-clients-python/lib/cflib/crazyflie/commander.py", line 73, in send_setpoint
    pk.data = struct.pack('<fffH', roll, -pitch, yaw, thrust)
error: ushort format requires 0 <= number <= USHRT_MAX
```

Which I determined to be resulting from `thrust` being passed as `-1`. I'm not sure if this is the appropriate fix, this is just the result of my exploration.

**Ideally, someone how knows the code better than I can probably make a much better patch.**

I see at [Line 295](https://github.com/Hoverbear/crazyflie-clients-python/blob/a38db9436351b7a658d1ed1ebe4221e2633aeefe/lib/cfclient/utils/input.py#L295) there is a line commented out which might be part of a yet-to-be-finished refinement.