### PR TITLE
Workaround for seqfault on Linux

### DIFF
--- a/lib/cfclient/cfclient.py
+++ b/lib/cfclient/cfclient.py
@@ -91,7 +91,14 @@ def main():
         logger.critical("No pyusb installation found, exiting!")
         sys.exit(1)
 
-    if not sys.platform.startswith('linux'):
+    # On linux systems use pygame instead of pysdl2
+    if sys.platform.startswith('linux'):
+        try:
+            import pygame
+        except ImportError:
+            logger.critical("No pygame installation found, exiting!")
+            sys.exit(1)
+    else:
         try:
             import sdl2
         except ImportError:


### PR DESCRIPTION
Arnaud told me that there should be no dependency on pygame any more, but apparently there still is.
This is a workaround to be able to start the client again on Linux until the underlying error is fixed.
If tested it on my machine and it works now.