### PR TITLE
Add option to change device address of CF2 during device scan and configuration

### DIFF
--- a/lib/cfclient/ui/dialogs/cf2config.py
+++ b/lib/cfclient/ui/dialogs/cf2config.py
@@ -74,6 +74,12 @@ class Cf2ConfigDialog(QtGui.QWidget, service_dialog_class):
         self._pitch_trim.setValue(mem.elements["pitch_trim"])
         self._radio_channel.setValue(mem.elements["radio_channel"])
         self._radio_speed.setCurrentIndex(mem.elements["radio_speed"])
+        if "radio_address" in mem.elements:
+            self._radio_address.setValue(mem.elements["radio_address"])
+            self._radio_address.setEnabled(True)
+        else:
+            self._radio_address.setValue(int("0xE7E7E7E7E7", 0))
+            self._radio_address.setEnabled(False)
         self._write_data_btn.setEnabled(True)
 
     def _set_ui_connected(self, link_uri):
@@ -87,6 +93,8 @@ class Cf2ConfigDialog(QtGui.QWidget, service_dialog_class):
         self._pitch_trim.setValue(0)
         self._radio_channel.setValue(0)
         self._radio_speed.setCurrentIndex(0)
+        self._radio_address.setValue(0)
+        self._radio_address.setEnabled(False)
 
     def _write_data(self):
         self._write_data_btn.setEnabled(False)
@@ -95,4 +103,6 @@ class Cf2ConfigDialog(QtGui.QWidget, service_dialog_class):
         mem.elements["roll_trim"] = self._roll_trim.value()
         mem.elements["radio_channel"] = self._radio_channel.value()
         mem.elements["radio_speed"] = self._radio_speed.currentIndex()
+        if "radio_address" in mem.elements:
+            mem.elements["radio_address"] = self._radio_address.value()
         mem.write_data(self._write_done)

--- a/lib/cfclient/ui/dialogs/cf2config.ui
+++ b/lib/cfclient/ui/dialogs/cf2config.ui
@@ -13,7 +13,7 @@
     <x>0</x>
     <y>0</y>
     <width>431</width>
-    <height>225</height>
+    <height>258</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -86,7 +86,7 @@
             </property>
            </widget>
           </item>
-          <item row="7" column="1">
+          <item row="8" column="1">
            <layout class="QGridLayout" name="gridLayout_4">
             <item row="0" column="1">
              <widget class="QPushButton" name="_exit_btn">
@@ -159,6 +159,17 @@
             </property>
            </widget>
           </item>
+          <item row="7" column="0">
+           <widget class="QLabel" name="label_10">
+            <property name="text">
+             <string>Radio Address:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="7" column="1">
+           <widget class="HexSpinBox" name="_radio_address">
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>
@@ -168,6 +179,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>HexSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>cfclient.ui.widgets.hexspinbox</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/lib/cfclient/ui/dialogs/connectiondialogue.py
+++ b/lib/cfclient/ui/dialogs/connectiondialogue.py
@@ -63,6 +63,7 @@ class ConnectDialogue(QtGui.QWidget, connect_widget_class):
         self.interfaceList.itemDoubleClicked.connect(self.interfaceSelected)
         self.scanner.interfaceFoundSignal.connect(self.foundInterfaces)
         self.box = None
+        self.address.setValue(0xE7E7E7E7E7)
 
         self.available_interfaces = []
 
@@ -73,7 +74,7 @@ class ConnectDialogue(QtGui.QWidget, connect_widget_class):
         self.scanButton.setEnabled(False)
         self.cancelButton.setEnabled(False)
         self.connectButton.setEnabled(False)
-        self.scanner.scanSignal.emit()
+        self.scanner.scanSignal.emit(self.address.value())
 
     def foundInterfaces(self, interfaces):
         """
@@ -109,7 +110,7 @@ class ConnectDialogue(QtGui.QWidget, connect_widget_class):
 
 class ScannerThread(QThread):
 
-    scanSignal = pyqtSignal()
+    scanSignal = pyqtSignal(object)
     interfaceFoundSignal = pyqtSignal(object)
 
     def __init__(self):
@@ -117,6 +118,5 @@ class ScannerThread(QThread):
         self.moveToThread(self)
         self.scanSignal.connect(self.scan)
 
-    @pyqtSlot()
-    def scan(self):
-        self.interfaceFoundSignal.emit(cflib.crtp.scan_interfaces())
+    def scan(self, address):
+        self.interfaceFoundSignal.emit(cflib.crtp.scan_interfaces(address))

--- a/lib/cfclient/ui/dialogs/connectiondialogue.ui
+++ b/lib/cfclient/ui/dialogs/connectiondialogue.ui
@@ -38,6 +38,27 @@
       <widget class="QListWidget" name="interfaceList"/>
      </item>
      <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Address:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="HexSpinBox" name="address">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
       <layout class="QGridLayout" name="gridLayout">
        <item row="1" column="0">
         <widget class="QPushButton" name="scanButton">
@@ -69,6 +90,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>HexSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>cfclient.ui.widgets.hexspinbox</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/lib/cfclient/ui/widgets/hexspinbox.py
+++ b/lib/cfclient/ui/widgets/hexspinbox.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+#     ||          ____  _ __
+#  +------+      / __ )(_) /_______________ _____  ___
+#  | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+#  +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#   ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+#  Copyright (C) 2011-2013 Bitcraze AB
+#
+#  Crazyflie Nano Quadcopter Client
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+"""
+This class provides a spin box with hexadecimal numbers and arbitrarily length (i.e. not limited by 32 bit).
+"""
+
+__author__ = 'Bitcraze AB'
+__all__ = ['HexSpinBox']
+
+from PyQt4 import QtGui, QtCore
+from PyQt4.QtGui import QAbstractSpinBox
+
+class HexSpinBox(QAbstractSpinBox):
+    def __init__(self, *args):
+        QAbstractSpinBox.__init__(self, *args)
+        regexp = QtCore.QRegExp('^0x[0-9A-Fa-f]{1,10}$')
+        self.validator = QtGui.QRegExpValidator(regexp)
+        self._value = 0
+
+    def validate(self, text, pos):
+        return self.validator.validate(text, pos)
+
+    def textFromValue(self, value):
+        return "0x%X" % value
+
+    def valueFromText(self, text):
+        return int(str(text), 0)
+
+    def setValue(self, value):
+        self._value = value
+        self.lineEdit().setText(self.textFromValue(value))
+
+    def value(self):
+        self._value = self.valueFromText(self.lineEdit().text())
+        return self._value
+
+    def stepBy(self, steps):
+        self.setValue(self._value + steps)
+
+    def stepEnabled(self):
+        return QAbstractSpinBox.StepUpEnabled | QAbstractSpinBox.StepDownEnabled

--- a/lib/cflib/crtp/__init__.py
+++ b/lib/cflib/crtp/__init__.py
@@ -56,14 +56,14 @@ def init_drivers(enable_debug_driver=False):
             continue
 
 
-def scan_interfaces():
+def scan_interfaces(address = None):
     """ Scan all the interfaces for available Crazyflies """
     available = []
     found = []
     for instance in INSTANCES:
         logger.debug("Scanning: %s", instance)
         try:
-            found = instance.scan_interface()
+            found = instance.scan_interface(address)
             available += found
         except Exception:
             raise

--- a/lib/cflib/crtp/crtpdriver.py
+++ b/lib/cflib/crtp/crtpdriver.py
@@ -75,10 +75,10 @@ class CRTPDriver:
         Return a human readable name of the interface.
         """
 
-    def scan_interface(self):
+    def scan_interface(self, address = None):
         """
         Scan interface for available Crazyflie quadcopters and return a list
-        witha them.
+        with them.
         """
 
     def enum(self):

--- a/lib/cflib/crtp/debugdriver.py
+++ b/lib/cflib/crtp/debugdriver.py
@@ -276,7 +276,7 @@ class DebugDriver (CRTPDriver):
                                                      self._fake_mems)
         self._packet_handler.start()
 
-    def scan_interface(self):
+    def scan_interface(self, address):
         return [["debug://0/0", "Normal connection"],
                 ["debug://0/1", "Fail to connect"],
                 ["debug://0/2", "Incomplete log TOC download"],

--- a/lib/cflib/crtp/serialdriver.py
+++ b/lib/cflib/crtp/serialdriver.py
@@ -58,5 +58,5 @@ class SerialDriver (CRTPDriver):
     def get_name(self):
         return "serial"
 
-    def scan_interface(self):
+    def scan_interface(self, address):
         return []

--- a/lib/cflib/crtp/udpdriver.py
+++ b/lib/cflib/crtp/udpdriver.py
@@ -101,5 +101,5 @@ class UdpDriver(CRTPDriver):
     def get_name(self):
         return "udp"
 
-    def scan_interface(self):
+    def scan_interface(self, address):
         return []

--- a/lib/cflib/crtp/usbdriver.py
+++ b/lib/cflib/crtp/usbdriver.py
@@ -179,7 +179,7 @@ class UsbDriver(CRTPDriver):
             pass
         self.cfusb = None
 
-    def scan_interface(self):
+    def scan_interface(self, address):
         """ Scan interface for Crazyflies """
         if self.cfusb is None:
             try:


### PR DESCRIPTION
This change is part 1 of supporting multiple Crazyflies by addressing them separately. There are additional parts required for the STM32 and NRF firmwares (I will sent those out shortly). The following change allows the UI to deal with multiple addresses, and (once firmware support is available) allows to configure the device address of a CF. The change specifically supports older and newer firmware versions. There is no support for CF1 yet, however it should be fairly simple to add. More details see below:

* Add new HexSpinBox as spinbox with hexadecimal values which can handle values > 32bit
* Add new device address field in CF2 config dialog. On older firmwares this option is disabled. However, on newer firmware versions it is possible to change the device address.
* Add device address field in connection dialog. This allows to scan channel/datarate if the device address is known. Use 0xE7E7E7E7E7 as default value.
* This change is fully compatible with old/new firmware versions.

Tested on Ubuntu 14.04 with CF2.0 using current firmware (i.e. no device address support) and custom firmware (i.e. with device address support).