### PR TITLE
Use python2 in shebang line

### DIFF
--- a/bin/cfloader
+++ b/bin/cfloader
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 #     ||          ____  _ __


### PR DESCRIPTION
Arch Linux uses Python 3 by default, so Python 2 should be reflected in the shebang line of cfloader.