### PR TITLE
Fixed Issue where InputInterface was replacing InputData class with hash

### DIFF
--- a/lib/cfclient/utils/input/inputinterfaces/__init__.py
+++ b/lib/cfclient/utils/input/inputinterfaces/__init__.py
@@ -93,6 +93,9 @@ class InputInterface(InputReaderInterface):
         self._reader.close(self.id)
 
     def read(self, include_raw=False):
-        self.data = self._reader.read(self.id)
+        mydata = self._reader.read(self.id)
+        # Merge interface returned data into InputReader Data Item
+        for key in mydata.keys():
+            self.data.set(key, mydata[key])
 
         return self.data


### PR DESCRIPTION
When attempting to using InputInterfaces on current version of python client I would receive and error that 

self.data.toggled was not defined in __dict__

I experienced this on both the LeapMotion and ZMQ interfaces (and would affect wiimote if used as well).  This was due to the InputData class being replaced in the Interface with data hash returned from the InputInterface.read method.  

I have updated the code to use the "set" method to update the InputData class instance.