### PR TITLE
Add battery voltage bar to flight controls tab

### DIFF
--- a/lib/cfclient/ui/tabs/flightTab.qss
+++ b/lib/cfclient/ui/tabs/flightTab.qss
@@ -1,0 +1,8 @@
+QProgressBar {
+    border: 1px solid #333;
+    background-color: transparent;
+}
+
+QProgressBar::chunk {
+    background-color: blue;
+}

--- a/lib/cfclient/ui/tabs/flightTab.ui
+++ b/lib/cfclient/ui/tabs/flightTab.ui
@@ -624,6 +624,26 @@
                 </property>
                </widget>
               </item>
+              <item row="1" column="12" rowspan="5">
+               <widget class="QProgressBar" name="batteryVoltage">
+                <property name="maximum">
+                 <number>65535</number>
+                </property>
+                <property name="value">
+                 <number>0</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="12">
+               <widget class="QLabel" name="batLabel">
+                <property name="text">
+                 <string>Bat</string>
+                </property>
+               </widget>
+              </item>
               <item row="1" column="2">
                <widget class="QLineEdit" name="targetThrust"/>
               </item>


### PR DESCRIPTION
Adds a new bar to the right of the M1-M4 bars showing the battery voltage as reported by the `pm.vbat` log variable, scaled between the hardcoded variables `BATTERY_VOLTAGE_MIN` and `BATTERY_VOLTAGE_MAX`. I got the value for the latter from the firmware source, and the former was determined via experimentation. Future work is to retrieve these values from the copter itself somehow.

The bar color is green when charging, red when in the low-power state, and blue otherwise. Unfortunately, styling the progress bar this way means we lose the pretty native styles, but I believe it's worth it.

This uncovered an odd behavior: when fully charged, the copter reports the `pm.state` variable as `battery`, rather than `charging` or `charged`, as would be expected (see possible values in `hal/interface/pm.h` in the firmware source). Would the maintainers be open to a PR to fix this?