### PR TITLE
Correctly set app name in menu bar in OS X, merge File->Exit into app menu

### DIFF
--- a/lib/cfclient/cfclient.py
+++ b/lib/cfclient/cfclient.py
@@ -117,6 +117,14 @@ def main():
         sys.stdout = os.fdopen(stdout, 'w')
         logger.info("Disabling STL printouts")
 
+    if sys.platform == 'darwin':
+        import Foundation
+        bundle = Foundation.NSBundle.mainBundle()
+        if bundle:
+            info = bundle.localizedInfoDictionary() or bundle.infoDictionary()
+            if info:
+                info['CFBundleName'] = 'Crazyflie'
+
     # Start up the main user-interface
     from ui.main import MainUI
     from PyQt4.QtGui import QApplication, QIcon

--- a/lib/cfclient/ui/main.py
+++ b/lib/cfclient/ui/main.py
@@ -181,6 +181,11 @@ class MainUI(QtGui.QMainWindow, main_window_class):
         self.joystickReader.device_discovery.add_callback(
                         self._input_discovery_signal.emit)
 
+        # Hide the 'File' menu on OS X, since its only item, 'Exit', gets
+        # merged into the application menu.
+        if sys.platform == 'darwin':
+            self.menuFile.menuAction().setVisible(False)
+
         # Connect UI signals
         self.menuItemConnect.triggered.connect(self._connect)
         self.logConfigAction.triggered.connect(self._show_connect_dialog)

--- a/lib/cfclient/ui/main.ui
+++ b/lib/cfclient/ui/main.ui
@@ -186,9 +186,9 @@
     <addaction name="separator"/>
     <addaction name="_menuItem_openconfigfolder"/>
    </widget>
-   <widget class="QMenu" name="menuCrazyflie">
+   <widget class="QMenu" name="menuConnect">
     <property name="title">
-     <string>Crazyflie</string>
+     <string>Connect</string>
     </property>
     <addaction name="menuItemConnect"/>
     <addaction name="menuItemQuickConnect"/>
@@ -205,7 +205,7 @@
     <addaction name="separator"/>
    </widget>
    <addaction name="menuFile"/>
-   <addaction name="menuCrazyflie"/>
+   <addaction name="menuConnect"/>
    <addaction name="_menu_inputdevice"/>
    <addaction name="menuSettings"/>
    <addaction name="menuView"/>
@@ -220,9 +220,6 @@
   <action name="menuItemExit">
    <property name="text">
     <string>Exit</string>
-   </property>
-   <property name="menuRole">
-    <enum>QAction::NoRole</enum>
    </property>
   </action>
   <action name="menuItemRegulation">


### PR DESCRIPTION
Rename the previous 'Crazyflie' menu to 'Connect' to avoid ambiguity. Also fixes selecting 'Quit' from the application menu.

Try as I might, I still can't get selecting 'Quit' from the context menu on the icon in the dock to work.