### PR TITLE
new color scheme for plotting window to increase legibility

### DIFF
--- a/src/cfclient/ui/tabs/PlotTab.py
+++ b/src/cfclient/ui/tabs/PlotTab.py
@@ -120,7 +120,17 @@ class PlotTab(Tab, plot_tab_class):
     _disconnected_signal = pyqtSignal(str)
     _connected_signal = pyqtSignal(str)
 
-    colors = ['g', 'b', 'm', 'r', 'y', 'c']
+    colors = [
+        ( 60, 200,  60), # green
+        ( 40, 120, 255), # blue
+        (255, 110, 240), # magenta
+        (255,  26,  28), # red
+        (255, 170,   0), # orange
+        ( 40, 180, 240), # cyan
+        (153, 153, 153), # grey
+        (176,  96,  50), # brown
+        (180,  60, 240), # purple
+    ]
 
     def __init__(self, tabWidget, helper, *args):
         super(PlotTab, self).__init__(*args)

--- a/src/cfclient/ui/tabs/PlotTab.py
+++ b/src/cfclient/ui/tabs/PlotTab.py
@@ -121,15 +121,15 @@ class PlotTab(Tab, plot_tab_class):
     _connected_signal = pyqtSignal(str)
 
     colors = [
-        ( 60, 200,  60), # green
-        ( 40, 120, 255), # blue
-        (255, 110, 240), # magenta
-        (255,  26,  28), # red
-        (255, 170,   0), # orange
-        ( 40, 180, 240), # cyan
-        (153, 153, 153), # grey
-        (176,  96,  50), # brown
-        (180,  60, 240), # purple
+        (60, 200, 60),    # green
+        (40, 100, 255),   # blue
+        (255, 130, 240),  # magenta
+        (255, 26, 28),    # red
+        (255, 170, 0),    # orange
+        (40, 180, 240),   # cyan
+        (153, 153, 153),  # grey
+        (176, 96, 50),    # brown
+        (180, 60, 240),   # purple
     ]
 
     def __init__(self, tabWidget, helper, *args):


### PR DESCRIPTION
The current color set for plots in the Python client includes a full (255, 255, 0) yellow which is very difficult to see on a white background, especially on high-resolution monitors. This pull request introduces a new set of colors that are more legible. The first 6 colors follow the order of the existing color set, so existing log blocks will have similar colors as before. 3 new colors are introduced to avoid cycling.

Tested on Ubuntu 14.04.