### PR TITLE
Fixed blank UI issue (at least on Macs)

### DIFF
--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -51,6 +51,7 @@ from PyQt4.QtCore import pyqtSlot
 from PyQt4.QtCore import QDir
 from PyQt4.QtCore import QThread
 from PyQt4.QtCore import QUrl
+from PyQt4.QtCore import QTimer
 from PyQt4.QtGui import QAction
 from PyQt4.QtGui import QActionGroup
 from PyQt4.QtGui import QDesktopServices
@@ -368,6 +369,14 @@ class MainUI(QtGui.QMainWindow, main_window_class):
 
         self._mapping_support = True
 
+        self.timer_repaint = QTimer()
+        self.timer_repaint.timeout.connect(self._repaint_UI)
+        self.timer_repaint.start()  # Delay of 0ms = Execute as soon as the event loop is done processing (as often as possible)
+
+    @pyqtSlot()
+    def _repaint_UI(self):
+        self.update()  # Seems to be better than self.repaint(), PyQt optimizes performance better with update(). repaint() also works fine though
+
     def interfaceChanged(self, interface):
         if interface == INTERFACE_PROMPT_TEXT:
             self._selected_interface = None
@@ -595,6 +604,7 @@ class MainUI(QtGui.QMainWindow, main_window_class):
             self._connect()
 
     def closeEvent(self, event):
+        self.timer_repaint.stop()  # Not really necessary, but never a bad idea to stop it
         self.hide()
         self.cf.close_link()
         Config().save_file()

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -371,11 +371,11 @@ class MainUI(QtGui.QMainWindow, main_window_class):
 
         self.timer_repaint = QTimer()
         self.timer_repaint.timeout.connect(self._repaint_UI)
-        self.timer_repaint.start()  # Delay of 0ms = Execute as soon as the event loop is done processing (as often as possible)
+        self.timer_repaint.start()  # 0ms delay = Execute when event loop idle
 
     @pyqtSlot()
     def _repaint_UI(self):
-        self.update()  # Seems to be better than self.repaint(), PyQt optimizes performance better with update(). repaint() also works fine though
+        self.update()  # Qt optimizs performance better with update vs repaint
 
     def interfaceChanged(self, interface):
         if interface == INTERFACE_PROMPT_TEXT:
@@ -604,7 +604,7 @@ class MainUI(QtGui.QMainWindow, main_window_class):
             self._connect()
 
     def closeEvent(self, event):
-        self.timer_repaint.stop()  # Not really necessary, but never a bad idea to stop it
+        self.timer_repaint.stop()  # Not really necessary, but why not
         self.hide()
         self.cf.close_link()
         Config().save_file()


### PR DESCRIPTION
At least on Mac, often the UI would not refresh/repaint (see attached image). This happened especially when moving the window accross displays, when other windows covered part of the CFclient, or when the client connected to a CF (it was very annoying). Before, the solutions (force a
repaint) I found were to either click on every component or trigger a PyQt repaint
(eg: maximizing the window). Now, a QTimer with timeout=0 (which means
it will be called whenever the event loop is available/done processing)
triggers a repaint and UI issues are gone! :)

![screen shot 2016-09-08 at 18 56 57](https://cloud.githubusercontent.com/assets/2836463/18376182/9f2afaee-7611-11e6-8f2f-13ebf6bd4137.png)

Tested on Mac OSX 10.10, Python 3.5.2 (homebrew'ed).