### PR TITLE
Force repaint for active tab's children widgets in OSX (#260 cont'd)

### DIFF
--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -35,6 +35,7 @@ import cfclient.ui.toolboxes
 import cflib.crtp
 from cfclient.ui.dialogs.about import AboutDialog
 from cfclient.ui.dialogs.bootloader import BootloaderDialog
+from cfclient.ui.widgets.plotwidget import PlotWidget
 from cfclient.utils.config import Config
 from cfclient.utils.config_manager import ConfigManager
 from cfclient.utils.input import JoystickReader
@@ -58,6 +59,7 @@ from PyQt4.QtGui import QDesktopServices
 from PyQt4.QtGui import QLabel
 from PyQt4.QtGui import QMenu
 from PyQt4.QtGui import QMessageBox
+from PyQt4.QtGui import QTreeView, QTreeWidget, QWidget, QTextEdit
 
 from .dialogs.cf1config import Cf1ConfigDialog
 from .dialogs.cf2config import Cf2ConfigDialog
@@ -382,6 +384,20 @@ class MainUI(QtGui.QMainWindow, main_window_class):
     @pyqtSlot()
     def _repaint_UI(self):
         self.update()  # Qt optimizs performance better with update vs repaint
+
+        # (Fix for issue #260). For some reason, certain widgets (param list,
+        # plotter, log TOC, GPS widget, console output...) in the active tab
+        # still won't get repainted after calling self.update(). Even calling
+        # update() or repaint() on each individual widget doesn't work.
+        # However, toggling the widget visibility twice seems to do the trick!
+        for i in self.tabs.currentWidget().children():
+            if type(i) is QTreeView or \
+                            type(i) is PlotWidget or \
+                            type(i) is QTreeWidget or \
+                            type(i) is QWidget or \
+                            type(i) is QTextEdit:
+                i.setVisible(False)
+                i.setVisible(True)
 
     def interfaceChanged(self, interface):
         if interface == INTERFACE_PROMPT_TEXT:

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -396,8 +396,12 @@ class MainUI(QtGui.QMainWindow, main_window_class):
                             type(i) is QTreeWidget or \
                             type(i) is QWidget or \
                             type(i) is QTextEdit:
-                i.setVisible(False)
-                i.setVisible(True)
+                # i.hide() followed by a i.show() accomplishes the same effect
+                # however that way, the selected widget in the active tab
+                # loses focus (very annoying when manually setting the range
+                # in the Plotter tab through the QSpinBoxes, for example).
+                i.resize(i.width()-1, i.height()-1)  # Make slightly smaller
+                i.resize(i.width()+1, i.height()+1)  # & back to original size
 
     def interfaceChanged(self, interface):
         if interface == INTERFACE_PROMPT_TEXT:


### PR DESCRIPTION
(Continuation of #260, which is a pyqtgraph-related bug that causes the UI not to repaint under certain circumstances in OSX)
For some reason, certain widgets (QTreeView, QTreeWidget, QTextEdit,
QWidget...) in the client's active tab still wouldn't get repainted after #260's fix. So while the previous Pull Request fixed the "blank UI" issue for all
children elements of the main window, the problem still remained for the param
list, plotter, log TOC, log block list, GPS widget, console output... (see a couple screenshots below)
This commit fixes it! :)
![screen shot 2016-09-22 at 16 45 17](https://cloud.githubusercontent.com/assets/2836463/18769677/0b228d7a-80e4-11e6-8047-bdeefc090a4e.png)
![screen shot 2016-09-22 at 16 44 32](https://cloud.githubusercontent.com/assets/2836463/18769686/29f700dc-80e4-11e6-8e2b-a090ed708a22.png)
