### PR TITLE
Put roll and pitch trim increment to 0.2

### DIFF
--- a/src/cfclient/utils/input/__init__.py
+++ b/src/cfclient/utils/input/__init__.py
@@ -471,13 +471,13 @@ class JoystickReader(object):
                 else:
                     # Update the user roll/pitch trim from device
                     if data.toggled.pitchNeg and data.pitchNeg:
-                        self.trim_pitch -= 1
+                        self.trim_pitch -= .2
                     if data.toggled.pitchPos and data.pitchPos:
-                        self.trim_pitch += 1
+                        self.trim_pitch += .2
                     if data.toggled.rollNeg and data.rollNeg:
-                        self.trim_roll -= 1
+                        self.trim_roll -= .2
                     if data.toggled.rollPos and data.rollPos:
-                        self.trim_roll += 1
+                        self.trim_roll += .2
 
                     if data.toggled.pitchNeg or data.toggled.pitchPos or \
                             data.toggled.rollNeg or data.toggled.rollPos:


### PR DESCRIPTION
Stationary flight is an interesting part of Crazyflie game.
To have easier control, the roll and pitch increment should be much lower than 1 degree. 0.2 is a good value, making stationary flight almost fixed with null roll and pitch commands, after a correct trim adjust. 
 Modifications:
	modified :         src/cfclient/utils/input/__init__.py