### PR TITLE
Shortcut keys for quit client and connect input device.

### DIFF
--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -53,6 +53,7 @@ from PyQt5.QtCore import QThread
 from PyQt5.QtCore import QUrl
 from PyQt5.QtWidgets import QAction
 from PyQt5.QtWidgets import QActionGroup
+from PyQt5.QtWidgets import QShortcut
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtWidgets import QLabel
 from PyQt5.QtWidgets import QMenu
@@ -202,6 +203,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         # TODO: Need to reload configs
         # ConfigManager().conf_needs_reload.add_callback(self._reload_configs)
 
+        self.connect_input = QShortcut("Ctrl+I", self.connectButton, self._connect)
         self.cf.connection_failed.add_callback(
             self.connectionFailedSignal.emit)
         self.connectionFailedSignal.connect(self._connection_failed)
@@ -458,7 +460,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             canConnect = self._selected_interface is not None
             self.menuItemConnect.setText("Connect to Crazyflie")
             self.menuItemConnect.setEnabled(canConnect)
-            self.connectButton.setText("Connect")
+            self.connectButton.setText("Connect Ctrl+I")
             self.connectButton.setToolTip(
                 "Connect to the Crazyflie on the selected interface")
             self.connectButton.setEnabled(canConnect)
@@ -477,7 +479,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self.setWindowTitle(s)
             self.menuItemConnect.setText("Disconnect")
             self.menuItemConnect.setEnabled(True)
-            self.connectButton.setText("Disconnect")
+            self.connectButton.setText("Disconnect Ctrl+I")
             self.connectButton.setToolTip("Disconnect from the Crazyflie")
             self.scanButton.setEnabled(False)
             self.logConfigAction.setEnabled(True)
@@ -499,9 +501,9 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self.interfaceCombo.setEnabled(False)
         elif self.uiState == UIState.SCANNING:
             self.setWindowTitle("Scanning ...")
-            self.connectButton.setText("Connect")
+            self.connectButton.setText("Connect Ctrl+I")
             self.menuItemConnect.setEnabled(False)
-            self.connectButton.setText("Connect")
+            self.connectButton.setText("Connect Ctrl+I")
             self.connectButton.setEnabled(False)
             self.scanButton.setText("Scanning...")
             self.scanButton.setEnabled(False)
@@ -561,6 +563,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             color = COLOR_RED
 
         self.batteryBar.setStyleSheet(progressbar_stylesheet(color))
+        self._aff_volts.setText(("%.3f" % data["pm.vbat"]))
 
     def _connected(self):
         self.uiState = UIState.CONNECTED
@@ -630,6 +633,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
                                      event.size().height()])
 
     def _connect(self):
+        logger.info("SSSSSSSSSSSSSsignal reçu")
         if self.uiState == UIState.CONNECTED:
             self.cf.close_link()
         elif self.uiState == UIState.CONNECTING:

--- a/src/cfclient/ui/main.ui
+++ b/src/cfclient/ui/main.ui
@@ -22,6 +22,34 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="6">
+         <widget class="QLineEdit" name="_aff_volts">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>48</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>48</width>
+            <height>20</height>
+           </size>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+          <property name="readOnly">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
         <item row="0" column="0">
          <widget class="QComboBox" name="interfaceCombo">
           <property name="minimumSize">
@@ -68,14 +96,14 @@
           </property>
          </spacer>
         </item>
-        <item row="0" column="6">
+        <item row="0" column="8">
          <widget class="QLabel" name="linkQualityLabel">
           <property name="text">
            <string>Link Quality:</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="7">
+        <item row="0" column="9">
          <widget class="QProgressBar" name="linkQualityBar">
           <property name="minimumSize">
            <size>
@@ -125,13 +153,13 @@
            </size>
           </property>
           <property name="minimum">
-           <number>3000</number>
+           <number>3400</number>
           </property>
           <property name="maximum">
-           <number>4200</number>
+           <number>4180</number>
           </property>
           <property name="value">
-           <number>3000</number>
+           <number>3800</number>
           </property>
           <property name="textVisible">
            <bool>true</bool>
@@ -144,6 +172,13 @@
           </property>
           <property name="format">
            <string>Battery %v mV</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="7">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string> volts </string>
           </property>
          </widget>
         </item>
@@ -211,7 +246,7 @@
            <x>0</x>
            <y>0</y>
            <width>852</width>
-           <height>500</height>
+           <height>498</height>
           </rect>
          </property>
          <property name="sizePolicy">
@@ -224,7 +259,16 @@
           <property name="sizeConstraint">
            <enum>QLayout::SetNoConstraint</enum>
           </property>
-          <property name="margin">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
            <number>0</number>
           </property>
           <item row="0" column="0">
@@ -254,7 +298,7 @@
      <x>0</x>
      <y>0</y>
      <width>872</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -310,12 +354,18 @@
   <widget class="QStatusBar" name="statusbar"/>
   <action name="menuItemConnect">
    <property name="text">
-    <string>Connect</string>
+    <string>Connect Ctrl+C</string>
+   </property>
+   <property name="shortcut">
+    <string/>
    </property>
   </action>
   <action name="menuItemExit">
    <property name="text">
     <string>Exit</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
    </property>
   </action>
   <action name="menuItemRegulation">


### PR DESCRIPTION
For keyboard "aficionados"... two shortcuts, to exit client and to connect to the found crazyflie. Also better battery display including voltage values. It's useful to have more information on the status of the battery installed.
Shortcut keys for quit client and connect input device. Also:
Battery voltage shown in Main UI.
Adapt voltage limits for battery.

 Modifications:
	modified :         src/cfclient/ui/main.py
	modified :         src/cfclient/ui/main.ui