### PR TITLE
Fix issue with saving log into file second time

### DIFF
--- a/src/cfclient/utils/logdatawriter.py
+++ b/src/cfclient/utils/logdatawriter.py
@@ -93,6 +93,7 @@ class LogWriter():
             logger.info("Stopped logging of block [%s] to file [%s]",
                         self._block.name, self._filename)
             self._header_values = []
+            self._header_written = False
 
     def start(self):
         """Start the logging to file"""


### PR DESCRIPTION
When tried to save log into csv file the second time, only first column (timestamp) is stored with no data. 
I found when data write stop requested, _header_written is not properly reset. 