### PR TITLE
#359 detect decks both by onewire and params

### DIFF
--- a/src/cfclient/configs/config.json
+++ b/src/cfclient/configs/config.json
@@ -14,6 +14,7 @@
     "max_rp": 30,
     "client_side_xmode": false,
     "auto_reconnect": false,
+    "keep_alive": false,
     "device_config_mapping": {},
     "enable_debug_driver": false,
     "input_device_blacklist": "(VirtualBox|VMware)",

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -244,6 +244,11 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self._auto_reconnect_changed)
         self.autoReconnectCheckBox.setChecked(Config().get("auto_reconnect"))
 
+        self._keep_alive_enabled = Config().get("keep_alive")
+        self.keepAliveCheckBox.toggled.connect(
+            self._keep_alive_changed)
+        self.keepAliveCheckBox.setChecked(Config().get("keep_alive"))
+
         self._disable_input = False
 
         self.joystickReader.input_updated.add_callback(
@@ -550,6 +555,19 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self._auto_reconnect_enabled = checked
         Config().set("auto_reconnect", checked)
         logger.info("Auto reconnect enabled: {}".format(checked))
+
+    def _keep_alive_changed(self, checked):
+        self._keep_alive_enabled = checked
+        Config().set("keep_alive", checked)
+        logger.info("Keep alive enabled: {}".format(checked))
+
+        if checked:
+            cflib.crtp.radiodriver.set_retries_before_disconnect(99999999999999999)  # never disconnect :)
+            cflib.crtp.radiodriver.set_retries(3)
+        else:
+            cflib.crtp.radiodriver.set_retries_before_disconnect(1500) # default
+            cflib.crtp.radiodriver.set_retries(3)
+        
 
     def _show_connect_dialog(self):
         self.logConfigDialogue.show()

--- a/src/cfclient/ui/main.ui
+++ b/src/cfclient/ui/main.ui
@@ -189,7 +189,7 @@
       </item>
       <item>
        <widget class="QGroupBox" name="groupBox">
-        <layout class="QHBoxLayout" stretch="0,0,1">
+        <layout class="QHBoxLayout" stretch="0,0,0,1">
          <item>
           <widget class="QLabel" name="addressLabel">
            <property name="text">
@@ -214,6 +214,19 @@
            </property>
            <property name="text">
             <string>Auto Reconnect</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="keepAliveCheckBox">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Keep Alive</string>
            </property>
            <property name="checked">
             <bool>false</bool>

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -593,7 +593,7 @@ class FlightTab(Tab, flight_tab_class):
             self._ring_effect_changed)
 
         self._led_ring_effect.setCurrentIndex(current)
-        if self.helper.cf.mem.ow_search(vid=0xBC, pid=0x01):
+        if bool(self.helper.cf.param.values["deck"]["bcLedRing"]):
             self._led_ring_effect.setEnabled(True)
             self._led_ring_headlight.setEnabled(True)
 
@@ -617,20 +617,20 @@ class FlightTab(Tab, flight_tab_class):
         heightHoldPossible = False
         hoverPossible = False
 
-        if self.helper.cf.mem.ow_search(vid=0xBC, pid=0x09):
+        if bool(self.helper.cf.param.values["deck"]["bcZRanger"]):
             heightHoldPossible = True
             self.helper.inputDeviceReader.set_hover_max_height(1.0)
 
-        if self.helper.cf.mem.ow_search(vid=0xBC, pid=0x0E):
+        if bool(self.helper.cf.param.values["deck"]["bcZRanger2"]):
             heightHoldPossible = True
             self.helper.inputDeviceReader.set_hover_max_height(2.0)
 
-        if self.helper.cf.mem.ow_search(vid=0xBC, pid=0x0A):
+        if bool(self.helper.cf.param.values["deck"]["bcFlow"]):
             heightHoldPossible = True
             hoverPossible = True
             self.helper.inputDeviceReader.set_hover_max_height(1.0)
 
-        if self.helper.cf.mem.ow_search(vid=0xBC, pid=0x0F):
+        if bool(self.helper.cf.param.values["deck"]["bcFlow2"]):
             heightHoldPossible = True
             hoverPossible = True
             self.helper.inputDeviceReader.set_hover_max_height(2.0)

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -579,7 +579,8 @@ class FlightTab(Tab, flight_tab_class):
                            12: "Gravity",
                            13: "LED tab",
                            14: "Color fader",
-                           15: "Link quality"}
+                           15: "Link quality",
+                           16: "Lighthouse quality"}
 
         for i in range(nbr + 1):
             name = "{}: ".format(i)


### PR DESCRIPTION
Resolves:

https://github.com/bitcraze/crazyflie-clients-python/issues/359

Have tested for LED Ring only

Uses 'or' operator to detect decks so it's a fairly safe change