### PR TITLE
Radio - Keep alive - Maintains connection 

### DIFF
--- a/src/cfclient/configs/config.json
+++ b/src/cfclient/configs/config.json
@@ -14,6 +14,7 @@
     "max_rp": 30,
     "client_side_xmode": false,
     "auto_reconnect": false,
+    "keep_alive": false,
     "device_config_mapping": {},
     "enable_debug_driver": false,
     "input_device_blacklist": "(VirtualBox|VMware)",

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -244,6 +244,11 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self._auto_reconnect_changed)
         self.autoReconnectCheckBox.setChecked(Config().get("auto_reconnect"))
 
+        self._keep_alive_enabled = Config().get("keep_alive")
+        self.keepAliveCheckBox.toggled.connect(
+            self._keep_alive_changed)
+        self.keepAliveCheckBox.setChecked(Config().get("keep_alive"))
+
         self._disable_input = False
 
         self.joystickReader.input_updated.add_callback(
@@ -550,6 +555,19 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self._auto_reconnect_enabled = checked
         Config().set("auto_reconnect", checked)
         logger.info("Auto reconnect enabled: {}".format(checked))
+
+    def _keep_alive_changed(self, checked):
+        self._keep_alive_enabled = checked
+        Config().set("keep_alive", checked)
+        logger.info("Keep alive enabled: {}".format(checked))
+
+        if checked:
+            cflib.crtp.radiodriver.set_retries_before_disconnect(99999999999999999)  # never disconnect :)
+            cflib.crtp.radiodriver.set_retries(3)
+        else:
+            cflib.crtp.radiodriver.set_retries_before_disconnect(1500) # default
+            cflib.crtp.radiodriver.set_retries(3)
+        
 
     def _show_connect_dialog(self):
         self.logConfigDialogue.show()

--- a/src/cfclient/ui/main.ui
+++ b/src/cfclient/ui/main.ui
@@ -189,7 +189,7 @@
       </item>
       <item>
        <widget class="QGroupBox" name="groupBox">
-        <layout class="QHBoxLayout" stretch="0,0,1">
+        <layout class="QHBoxLayout" stretch="0,0,0,1">
          <item>
           <widget class="QLabel" name="addressLabel">
            <property name="text">
@@ -214,6 +214,19 @@
            </property>
            <property name="text">
             <string>Auto Reconnect</string>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="keepAliveCheckBox">
+           <property name="mouseTracking">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Keep Alive</string>
            </property>
            <property name="checked">
             <bool>false</bool>


### PR DESCRIPTION
Default behaviour will disconnect the CF when lost connection for about 1sec

Added a "keep-alive" tick box beside "auto-connect" so that it pretty much never disconnect, and keep retrying for 99999999999999999 times (default retires for 1500 times)

99999999999999999 may be bad way to do this, but it works.
Any suggestion?

Also, the "auto-connect" doesn't seem to work, can't see any difference enabling it.
The "keep-alive" seems to be do a better job
