### PR TITLE
relax pyzmq dep

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
 
     install_requires=platform_requires + ['cflib>=0.1.9',
                                           'appdirs>=1.4.0',
-                                          'pyzmq==18.1.0',
+                                          'pyzmq>=18.1.0',
                                           'pyqtgraph>=0.10',
                                           'PyYAML>=5.1.2',
                                           'quamash==0.6.1',


### PR DESCRIPTION
This allows the package to built under Arch Linux using native libraries.
See https://aur.archlinux.org/packages/python-cfclient/ for the Arch Linux package.