### PR TITLE
Enabled sorting of some log-tags regarding #404

### DIFF
--- a/src/cfclient/ui/tabs/LogBlockTab.py
+++ b/src/cfclient/ui/tabs/LogBlockTab.py
@@ -176,6 +176,7 @@ class LogBlockModel(QAbstractItemModel):
     def add_block(self, block, connected_ts):
         self._nodes.append(LogBlockItem(block, self, connected_ts))
         self.layoutChanged.emit()
+        self._nodes.sort(key=lambda conf: conf.name.lower())
 
     def refresh(self):
         """Force a refresh of the view though the model"""

--- a/src/cfclient/ui/tabs/LogTab.py
+++ b/src/cfclient/ui/tabs/LogTab.py
@@ -60,6 +60,8 @@ class LogTab(Tab, param_tab_class):
 
         # Init the tree widget
         self.logTree.setHeaderLabels(['Name', 'ID', 'Unpack', 'Storage'])
+        self.logTree.setSortingEnabled(True)
+        self.logTree.sortItems(0, Qt.AscendingOrder)
 
         self.cf.connected.add_callback(self.connectedSignal.emit)
         self.connectedSignal.connect(self.connected)
@@ -90,4 +92,3 @@ class LogTab(Tab, param_tab_class):
                 groupItem.addChild(item)
 
             self.logTree.addTopLevelItem(groupItem)
-            self.logTree.expandItem(groupItem)

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -253,7 +253,6 @@ class ParamTab(Tab, param_tab_class):
 
     def _connected(self, link_uri):
         self._model.set_toc(self.cf.param.toc.toc, self.helper.cf)
-        self.paramTree.expandAll()
 
     def _disconnected(self, link_uri):
         self._model.beginResetModel()


### PR DESCRIPTION
The log-tab is now sorted in alphabetical order (by name) on startup.
The child items are not expanded by default anymore.