### PR TITLE
Removed 2 traces of python 2, regarding #401

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 git:
   depth: 150
 python:
-  - "2.7"
+  - "3.6"
 services:
   - docker
 before_install:

--- a/examples/zmqsrvtest.py
+++ b/examples/zmqsrvtest.py
@@ -31,8 +31,6 @@ ZMQ server test application. Use CTRL-C to end the application.
 NOTE! If connected to a Crazyflie this will power on the motors!
 """
 
-from __future__ import print_function
-
 from threading import Thread
 import signal
 import time


### PR DESCRIPTION
Source code is clean from python 2 traces.
There are still some documentation pages that contain traces though, like https://www.bitcraze.io/documentation/repository/crazyflie-clients-python/master/installation/macports/ 