### PR TITLE
Changed the columns in flight-tab and added logging of X and Y from estimator.

### DIFF
--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -45,7 +45,9 @@ from cfclient.utils.input import JoystickReader
 
 from cfclient.ui.tab import Tab
 
-LOG_NAME_ESTIMATED_Z = "stateEstimate.z"
+LOG_NAME_ESTIMATE_X = 'stateEstimate.x'
+LOG_NAME_ESTIMATE_Y = 'stateEstimate.y'
+LOG_NAME_ESTIMATE_Z = 'stateEstimate.z'
 
 __author__ = 'Bitcraze AB'
 __all__ = ['FlightTab']
@@ -245,41 +247,61 @@ class FlightTab(Tab, flight_tab_class):
 
     def _baro_data_received(self, timestamp, data, logconf):
         if self.isVisible():
-            estimated_z = data[LOG_NAME_ESTIMATED_Z]
-            self.actualHeight.setText(("%.2f" % estimated_z))
+            estimated_x = data[LOG_NAME_ESTIMATE_X]
+            estimated_y = data[LOG_NAME_ESTIMATE_Y]
+            estimated_z = data[LOG_NAME_ESTIMATE_Z]
+            self.estimateX.setText(("%.2f" % estimated_x))
+            self.estimateY.setText(("%.2f" % estimated_y))
+            self.estimateZ.setText(("%.2f" % estimated_z))
             self.ai.setBaro(estimated_z, self.is_visible())
 
     def _heighthold_input_updated(self, roll, pitch, yaw, height):
         if (self.isVisible() and
                 (self.helper.inputDeviceReader.get_assisted_control() ==
                  self.helper.inputDeviceReader.ASSISTED_CONTROL_HEIGHTHOLD)):
+
             self.targetRoll.setText(("%0.2f deg" % roll))
             self.targetPitch.setText(("%0.2f deg" % pitch))
             self.targetYaw.setText(("%0.2f deg/s" % yaw))
             self.targetHeight.setText(("%.2f m" % height))
             self.ai.setHover(height, self.is_visible())
 
+            self._change_input_labels(using_hover_assist=False)
+
     def _hover_input_updated(self, vx, vy, yaw, height):
         if (self.isVisible() and
                 (self.helper.inputDeviceReader.get_assisted_control() ==
                  self.helper.inputDeviceReader.ASSISTED_CONTROL_HOVER)):
+
             self.targetRoll.setText(("%0.2f m/s" % vy))
             self.targetPitch.setText(("%0.2f m/s" % vx))
             self.targetYaw.setText(("%0.2f deg/s" % yaw))
             self.targetHeight.setText(("%.2f m" % height))
             self.ai.setHover(height, self.is_visible())
 
+            self._change_input_labels(using_hover_assist=True)
+
     def _imu_data_received(self, timestamp, data, logconf):
         if self.isVisible():
-            self.actualRoll.setText(("%.2f" % data["stabilizer.roll"]))
-            self.actualPitch.setText(("%.2f" % data["stabilizer.pitch"]))
-            self.actualYaw.setText(("%.2f" % data["stabilizer.yaw"]))
-            self.actualThrust.setText("%.2f%%" %
-                                      self.thrustToPercentage(
-                                          data["stabilizer.thrust"]))
+            self.estimateRoll.setText(("%.2f" % data["stabilizer.roll"]))
+            self.estimatePitch.setText(("%.2f" % data["stabilizer.pitch"]))
+            self.estimateYaw.setText(("%.2f" % data["stabilizer.yaw"]))
+            self.estimateThrust.setText("%.2f%%" %
+                                        self.thrustToPercentage(
+                                            data["stabilizer.thrust"]))
 
             self.ai.setRollPitch(-data["stabilizer.roll"],
                                  data["stabilizer.pitch"], self.is_visible())
+
+    def _change_input_labels(self, using_hover_assist):
+        if using_hover_assist:
+            pitch, roll, yaw = 'Velocity X', 'Velocity Y', 'Velocity Z'
+        else:
+            pitch, roll, yaw = 'Pitch', 'Roll', 'Yaw'
+
+        self.inputPitchLabel.setText(pitch)
+        self.inputRollLabel.setText(roll)
+        self.inputYawLabel.setText(yaw)
 
     def connected(self, linkURI):
         # IMU & THRUST
@@ -316,16 +338,24 @@ class FlightTab(Tab, flight_tab_class):
         except AttributeError as e:
             logger.warning(str(e))
 
+    def _enable_estimators(self, should_enable):
+        self.estimateX.setEnabled(should_enable)
+        self.estimateY.setEnabled(should_enable)
+        self.estimateZ.setEnabled(should_enable)
+
     def _set_available_sensors(self, name, available):
         logger.info("[%s]: %s", name, available)
         available = eval(available)
 
-        self.actualHeight.setEnabled(True)
+        self._enable_estimators(True)
+
         self.helper.inputDeviceReader.set_alt_hold_available(available)
         if not self.logBaro:
             # The sensor is available, set up the logging
             self.logBaro = LogConfig("Baro", 200)
-            self.logBaro.add_variable(LOG_NAME_ESTIMATED_Z, "float")
+            self.logBaro.add_variable(LOG_NAME_ESTIMATE_X, "float")
+            self.logBaro.add_variable(LOG_NAME_ESTIMATE_Y, "float")
+            self.logBaro.add_variable(LOG_NAME_ESTIMATE_Z, "float")
 
             try:
                 self.helper.cf.log.add_config(self.logBaro)
@@ -345,15 +375,21 @@ class FlightTab(Tab, flight_tab_class):
         self.actualM2.setValue(0)
         self.actualM3.setValue(0)
         self.actualM4.setValue(0)
-        self.actualRoll.setText("")
-        self.actualPitch.setText("")
-        self.actualYaw.setText("")
-        self.actualThrust.setText("")
-        self.actualHeight.setText("")
+
+        self.estimateRoll.setText("")
+        self.estimatePitch.setText("")
+        self.estimateYaw.setText("")
+        self.estimateThrust.setText("")
+        self.estimateX.setText("")
+        self.estimateY.setText("")
+        self.estimateZ.setText("")
+
         self.targetHeight.setText("Not Set")
         self.ai.setHover(0, self.is_visible())
         self.targetHeight.setEnabled(False)
-        self.actualHeight.setEnabled(False)
+
+        self._enable_estimators(False)
+
         self.logBaro = None
         self.logAltHold = None
         self._led_ring_effect.setEnabled(False)
@@ -427,6 +463,8 @@ class FlightTab(Tab, flight_tab_class):
         self.targetThrust.setText(("%0.2f %%" %
                                    self.thrustToPercentage(thrust)))
         self.thrustProgress.setValue(thrust)
+
+        self._change_input_labels(using_hover_assist=False)
 
     def setMotorLabelsEnabled(self, enabled):
         self.M1label.setEnabled(enabled)
@@ -509,6 +547,7 @@ class FlightTab(Tab, flight_tab_class):
                  JoystickReader.ASSISTED_CONTROL_HOVER)):
             self.targetThrust.setEnabled(not enabled)
             self.targetHeight.setEnabled(enabled)
+            print('Chaning enable for target height: %s' % enabled)
         else:
             self.helper.cf.param.set_value("flightmode.althold", str(enabled))
 

--- a/src/cfclient/ui/tabs/flightTab.ui
+++ b/src/cfclient/ui/tabs/flightTab.ui
@@ -391,7 +391,7 @@
              <layout class="QVBoxLayout" name="verticalLayout_4"/>
             </widget>
             <widget class="QWidget" name="layoutWidget">
-             <layout class="QGridLayout" name="gridLayout_5" rowstretch="0,3,3,3,3,3" rowminimumheight="1,1,1,1,1,1">
+             <layout class="QGridLayout" name="gridLayout_5" rowstretch="0,0,0,0,0,0,0,0,0">
               <property name="sizeConstraint">
                <enum>QLayout::SetMinimumSize</enum>
               </property>
@@ -401,17 +401,158 @@
               <property name="verticalSpacing">
                <number>0</number>
               </property>
-              <item row="5" column="0">
+              <item row="2" column="5">
+               <widget class="QLineEdit" name="estimateX">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="5">
+               <widget class="QLineEdit" name="estimateZ">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="2">
+               <widget class="QLineEdit" name="targetHeight">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="4">
+               <widget class="QLabel" name="label_19">
+                <property name="text">
+                 <string>X</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
+               <widget class="QLabel" name="label_20">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="text">
+                 <string>State Estimate</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="4">
+               <widget class="QLabel" name="label_23">
+                <property name="text">
+                 <string>Yaw</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="4">
+               <widget class="QLabel" name="label_18">
+                <property name="text">
+                 <string>Y</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="4">
+               <widget class="QLabel" name="label_10">
+                <property name="text">
+                 <string>Z</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="5">
+               <widget class="QLineEdit" name="estimateThrust">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="5">
+               <widget class="QLineEdit" name="estimateY">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QLabel" name="inputYawLabel">
+                <property name="text">
+                 <string>Yaw</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="QLineEdit" name="targetThrust">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="4">
                <widget class="QLabel" name="label_17">
+                <property name="text">
+                 <string>Pitch</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0">
+               <widget class="QLabel" name="inputHeightLabel">
                 <property name="text">
                  <string>Height</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="4">
-               <widget class="QLineEdit" name="actualPitch"/>
+              <item row="1" column="3">
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
-              <item row="1" column="8" rowspan="5">
+              <item row="1" column="4">
+               <widget class="QLabel" name="label_21">
+                <property name="text">
+                 <string>Thrust</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="9" rowspan="7">
                <widget class="QProgressBar" name="actualM1">
                 <property name="maximum">
                  <number>65535</number>
@@ -424,7 +565,7 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="10" rowspan="5">
+              <item row="1" column="11" rowspan="7">
                <widget class="QProgressBar" name="actualM3">
                 <property name="maximum">
                  <number>65535</number>
@@ -437,30 +578,16 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="6">
-               <widget class="QLabel" name="label_6">
-                <property name="text">
-                 <string>Thrust</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="4">
-               <widget class="QLineEdit" name="actualHeight">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string/>
-                </property>
-               </widget>
-              </item>
               <item row="0" column="2">
                <widget class="QLabel" name="label_14">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
                 <property name="text">
-                 <string>Target</string>
+                 <string>Gamepad Input</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignCenter</set>
@@ -468,9 +595,117 @@
                </widget>
               </item>
               <item row="3" column="2">
-               <widget class="QLineEdit" name="targetRoll"/>
+               <widget class="QLineEdit" name="targetRoll">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
               </item>
-              <item row="1" column="6" rowspan="5">
+              <item row="0" column="9">
+               <widget class="QLabel" name="M1label">
+                <property name="text">
+                 <string>M1</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLabel" name="inputRollLabel">
+                <property name="text">
+                 <string>Roll</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="11">
+               <widget class="QLabel" name="M3label">
+                <property name="text">
+                 <string>M3</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="2">
+               <widget class="QLineEdit" name="targetYaw">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="10" rowspan="7">
+               <widget class="QProgressBar" name="actualM2">
+                <property name="maximum">
+                 <number>65535</number>
+                </property>
+                <property name="value">
+                 <number>0</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QLineEdit" name="targetPitch">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="inputPitchLabel">
+                <property name="text">
+                 <string>Pitch</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="10">
+               <widget class="QLabel" name="M2label">
+                <property name="text">
+                 <string>M2</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="12" rowspan="7">
+               <widget class="QProgressBar" name="actualM4">
+                <property name="maximum">
+                 <number>65535</number>
+                </property>
+                <property name="value">
+                 <number>0</number>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="12">
+               <widget class="QLabel" name="M4label">
+                <property name="text">
+                 <string>M4</string>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="5">
+               <widget class="QLineEdit" name="estimateYaw">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="14" rowspan="8">
+               <layout class="QGridLayout" name="gridLayout_7"/>
+              </item>
+              <item row="1" column="7" rowspan="7">
                <widget class="QProgressBar" name="thrustProgress">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
@@ -501,126 +736,76 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_16">
-                <property name="text">
-                 <string>Thrust</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="8">
-               <widget class="QLabel" name="M1label">
-                <property name="text">
-                 <string>M1</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QLabel" name="label_12">
+              <item row="6" column="4">
+               <widget class="QLabel" name="label_22">
                 <property name="text">
                  <string>Roll</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="10">
-               <widget class="QLabel" name="M3label">
-                <property name="text">
-                 <string>M3</string>
+              <item row="6" column="5">
+               <widget class="QLineEdit" name="estimateRoll">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
                 </property>
                </widget>
               </item>
-              <item row="4" column="2">
-               <widget class="QLineEdit" name="targetYaw"/>
-              </item>
-              <item row="1" column="9" rowspan="5">
-               <widget class="QProgressBar" name="actualM2">
-                <property name="maximum">
-                 <number>65535</number>
-                </property>
-                <property name="value">
-                 <number>0</number>
-                </property>
+              <item row="1" column="6">
+               <spacer name="horizontalSpacer_3">
                 <property name="orientation">
-                 <enum>Qt::Vertical</enum>
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Fixed</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="13">
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="inputThrustLabel">
+                <property name="text">
+                 <string>Thrust</string>
                 </property>
                </widget>
               </item>
-              <item row="2" column="2">
-               <widget class="QLineEdit" name="targetPitch"/>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_11">
-                <property name="text">
-                 <string>Pitch</string>
+              <item row="5" column="5">
+               <widget class="QLineEdit" name="estimatePitch">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
                 </property>
                </widget>
               </item>
-              <item row="0" column="4">
-               <widget class="QLabel" name="label_15">
+              <item row="0" column="7">
+               <widget class="QLabel" name="label_6">
                 <property name="text">
-                 <string>Actual</string>
+                 <string>Thrust</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="4">
-               <widget class="QLineEdit" name="actualYaw"/>
-              </item>
-              <item row="0" column="9">
-               <widget class="QLabel" name="M2label">
-                <property name="text">
-                 <string>M2</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="11" rowspan="5">
-               <widget class="QProgressBar" name="actualM4">
-                <property name="maximum">
-                 <number>65535</number>
-                </property>
-                <property name="value">
-                 <number>0</number>
-                </property>
-                <property name="orientation">
-                 <enum>Qt::Vertical</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QLineEdit" name="targetThrust"/>
-              </item>
-              <item row="0" column="11">
-               <widget class="QLabel" name="M4label">
-                <property name="text">
-                 <string>M4</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="4">
-               <widget class="QLineEdit" name="actualThrust"/>
-              </item>
-              <item row="0" column="12" rowspan="6">
-               <layout class="QGridLayout" name="gridLayout_7"/>
-              </item>
-              <item row="4" column="0">
-               <widget class="QLabel" name="label_13">
-                <property name="text">
-                 <string>Yaw</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="4">
-               <widget class="QLineEdit" name="actualRoll"/>
-              </item>
-              <item row="5" column="2">
-               <widget class="QLineEdit" name="targetHeight">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string/>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
Changed the 'Target vs Actual' columns to 'Gamepad Input' and 'State Estimate' columns in the flight-control tab.
Also added logging of x and y from the estimator, instead of only z as before. 
The labels are also changed to Velocity X/Y/Z, when the crazyflie is flying with assist-mode on.
This pull request is done because of #408.