### PR TITLE
Read and set radio address from config if possible

### DIFF
--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -185,6 +185,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
         self._connectivity_manager.connect_button_clicked.connect(self._connect)
         self._connectivity_manager.scan_button_clicked.connect(self._scan)
+        self._set_address()
 
         self._auto_reconnect_enabled = Config().get("auto_reconnect")
         self.autoReconnectCheckBox.toggled.connect(
@@ -359,6 +360,17 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self._theme_checkboxes.append(node)
             self._theme_group.addAction(node)
             self.menuThemes.addAction(node)
+
+    def _set_address(self):
+        address = 0xE7E7E7E7E7
+        try:
+            link_uri = Config().get("link_uri")
+            if len(link_uri) > 0:
+                address = int(link_uri.split('/')[-1], 16)
+        except Exception as err:
+            logger.warn('failed to parse address from config: %s' % str(err))
+        finally:
+            self.address.setValue(address)
 
     def _theme_selected(self, *args):
         """ Callback when a theme is selected. """


### PR DESCRIPTION
If we have a stored link_uri in the user config we parse it and set the address field in the main UI to this value. This can save time for someone who has changed their address for their single Crazyflie which they are working with.

Closes #382