### PR TITLE
Add support for flashing the lighthouse deck FW from the bootloader dialog

### DIFF
--- a/src/cfclient/ui/dialogs/anchor_position_dialog.py
+++ b/src/cfclient/ui/dialogs/anchor_position_dialog.py
@@ -161,13 +161,12 @@ class AnchorPositionConfigTableModel(QAbstractTableModel):
 
 class AnchorPositionDialog(QtWidgets.QWidget, anchor_postiong_widget_class):
 
-    def __init__(self, lps_tab, *args):
-        super(AnchorPositionDialog, self).__init__(*args)
+    def __init__(self, lps_tab, helper):
+        super(AnchorPositionDialog, self).__init__()
         self.setupUi(self)
 
-        self._current_folder = os.path.expanduser('~')
-
         self._lps_tab = lps_tab
+        self._helper = helper
 
         self._headers = ['', 'id', 'x', 'y', 'z']
         self._data_model = AnchorPositionConfigTableModel(self._headers, self)
@@ -213,14 +212,12 @@ class AnchorPositionDialog(QtWidgets.QWidget, anchor_postiong_widget_class):
         self._data_model.anchor_postions_updated(anchor_positions)
 
     def _load_button_clicked(self):
-        names = QFileDialog.getOpenFileName(self, 'Open file',
-                                            self._current_folder,
-                                            "*.yaml;;*.*")
+        names = QFileDialog.getOpenFileName(self, 'Open file', self._helper.current_folder, "*.yaml;*.*")
 
         if names[0] == '':
             return
 
-        self._current_folder = os.path.dirname(names[0])
+        self._helper.current_folder = os.path.dirname(names[0])
 
         f = open(names[0], 'r')
         with f:
@@ -237,14 +234,12 @@ class AnchorPositionDialog(QtWidgets.QWidget, anchor_postiong_widget_class):
         for id, pos in anchor_positions.items():
             data[id] = {'x': pos[0], 'y': pos[1], 'z': pos[2]}
 
-        names = QFileDialog.getSaveFileName(self, 'Save file',
-                                            self._current_folder,
-                                            "*.yaml;;*.*")
+        names = QFileDialog.getSaveFileName(self, 'Save file', self._helper.current_folder, "*.yaml;*.*")
 
         if names[0] == '':
             return
 
-        self._current_folder = os.path.dirname(names[0])
+        self._helper.current_folder = os.path.dirname(names[0])
 
         if not names[0].endswith(".yaml") and names[0].find(".") < 0:
             filename = names[0] + ".yaml"

--- a/src/cfclient/ui/dialogs/anchor_position_dialog.py
+++ b/src/cfclient/ui/dialogs/anchor_position_dialog.py
@@ -221,7 +221,7 @@ class AnchorPositionDialog(QtWidgets.QWidget, anchor_postiong_widget_class):
 
         f = open(names[0], 'r')
         with f:
-            data = yaml.load(f)
+            data = yaml.safe_load(f)
 
             anchor_positions = {}
             for id, pos in data.items():

--- a/src/cfclient/ui/dialogs/bootloader.py
+++ b/src/cfclient/ui/dialogs/bootloader.py
@@ -228,7 +228,6 @@ class BootloaderDialog(QtWidgets.QWidget, service_dialog_class):
         self.clt.terminate_flashing()
         # Remove downloaded-firmware files.
         self.firmware_downloader.bootload_complete.emit()
-        self.resetCopter()
 
     def _populate_firmware_dropdown(self, releases):
         """ Callback from firmware-downloader that retrieves all
@@ -315,11 +314,11 @@ class BootloaderDialog(QtWidgets.QWidget, service_dialog_class):
         if success:
             self.statusLabel.setText('Status: <b>Programing complete!</b>')
             self.downloadStatus.setText('')
-
         else:
             self.statusLabel.setText('Status: <b>Programing failed!</b>')
 
         self.setUiState(self.UIState.DISCONNECTED)
+        self.resetCopter()
 
     @pyqtSlot(str, int)
     def statusUpdate(self, status, progress):

--- a/src/cfclient/ui/dialogs/bootloader.py
+++ b/src/cfclient/ui/dialogs/bootloader.py
@@ -253,7 +253,7 @@ class BootloaderDialog(QtWidgets.QWidget, service_dialog_class):
         filename = names[0]
         self._helper.current_folder = os.path.dirname(filename)
 
-        if filename[-4:] in ('.zip'):
+        if filename.endswith('.zip'):
             self.imagePathLine.setText(filename)
         else:
             msgBox = QtWidgets.QMessageBox()

--- a/src/cfclient/ui/dialogs/bootloader.ui
+++ b/src/cfclient/ui/dialogs/bootloader.ui
@@ -31,7 +31,7 @@
         <item>
          <widget class="QTabWidget" name="tabWidget">
           <property name="currentIndex">
-           <number>0</number>
+           <number>1</number>
           </property>
           <widget class="QWidget" name="tab">
            <attribute name="title">
@@ -127,13 +127,6 @@
               </property>
               <property name="text">
                <string>Restart in firmware mode</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="_cancel_bootloading">
-              <property name="text">
-               <string>Cancel bootloading</string>
               </property>
              </widget>
             </item>
@@ -306,6 +299,13 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>The Crazyflie may restart one or more times during the programming process </string>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QPushButton" name="programButton">

--- a/src/cfclient/ui/dialogs/bootloader.ui
+++ b/src/cfclient/ui/dialogs/bootloader.ui
@@ -295,37 +295,6 @@
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <widget class="QLabel" name="chipSelectLabel">
-         <property name="text">
-          <string>Chip to flash:</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="radioBoth">
-         <property name="text">
-          <string>Both</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="radioStm32">
-         <property name="text">
-          <string>stm32</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QRadioButton" name="radioNrf51">
-         <property name="text">
-          <string>nrf51</string>
-         </property>
-        </widget>
-       </item>
-       <item>
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>

--- a/src/cfclient/ui/main.ui
+++ b/src/cfclient/ui/main.ui
@@ -189,7 +189,7 @@
       </item>
       <item>
        <widget class="QGroupBox" name="groupBox">
-        <layout class="QHBoxLayout" stretch="0,0,1">
+        <layout class="QHBoxLayout" stretch="0,0,0">
          <item>
           <widget class="QLabel" name="addressLabel">
            <property name="text">
@@ -214,17 +214,17 @@
           </widget>
          </item>
          <item>
-          <widget class="QCheckBox" name="autoReconnectCheckBox">
-           <property name="mouseTracking">
-            <bool>false</bool>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
            </property>
-           <property name="text">
-            <string>Auto Reconnect</string>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
            </property>
-           <property name="checked">
-            <bool>false</bool>
-           </property>
-          </widget>
+          </spacer>
          </item>
         </layout>
        </widget>
@@ -254,8 +254,8 @@
           <rect>
            <x>0</x>
            <y>0</y>
-           <width>852</width>
-           <height>493</height>
+           <width>846</width>
+           <height>469</height>
           </rect>
          </property>
          <property name="sizePolicy">
@@ -307,7 +307,7 @@
      <x>0</x>
      <y>0</y>
      <width>872</width>
-     <height>22</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/src/cfclient/ui/pluginhelper.py
+++ b/src/cfclient/ui/pluginhelper.py
@@ -28,6 +28,7 @@
 """
 Used for passing objects to tabs and toolboxes.
 """
+import os
 
 __author__ = 'Bitcraze AB'
 __all__ = ['PluginHelper']
@@ -44,3 +45,4 @@ class PluginHelper():
         self.plotTab = None
         self.pose_logger = None
         self.connectivity_manager = None
+        self.current_folder = os.path.expanduser('~')

--- a/src/cfclient/ui/tabs/lighthouse_tab.py
+++ b/src/cfclient/ui/tabs/lighthouse_tab.py
@@ -352,8 +352,6 @@ class LighthouseTab(Tab, lighthouse_tab_class):
         self._load_sys_config_button.clicked.connect(self._load_sys_config_button_clicked)
         self._save_sys_config_button.clicked.connect(self._save_sys_config_button_clicked)
 
-        self._current_folder = os.path.expanduser('~')
-
         self._is_connected = False
         self._update_ui()
 
@@ -634,14 +632,12 @@ class LighthouseTab(Tab, lighthouse_tab_class):
                     label.setToolTip('')
 
     def _load_sys_config_button_clicked(self):
-        names = QFileDialog.getOpenFileName(self, 'Open file',
-                                            self._current_folder,
-                                            "*.yaml;;*.*")
+        names = QFileDialog.getOpenFileName(self, 'Open file', self._helper.current_folder, "*.yaml;*.*")
 
         if names[0] == '':
             return
 
-        self._current_folder = os.path.dirname(names[0])
+        self._helper.current_folder = os.path.dirname(names[0])
 
         if self._lh_config_writer is not None:
             self._lh_config_writer.write_and_store_config_from_file(self._new_system_config_written_to_cf_signal.emit,
@@ -657,14 +653,12 @@ class LighthouseTab(Tab, lighthouse_tab_class):
         self._save_sys_config(self._lh_geos, calibs)
 
     def _save_sys_config(self, geos, calibs):
-        names = QFileDialog.getSaveFileName(self, 'Save file',
-                                            self._current_folder,
-                                            "*.yaml;;*.*")
+        names = QFileDialog.getSaveFileName(self, 'Save file', self._helper.current_folder, "*.yaml;*.*")
 
         if names[0] == '':
             return
 
-        self._current_folder = os.path.dirname(names[0])
+        self._helper.current_folder = os.path.dirname(names[0])
 
         if not names[0].endswith(".yaml") and names[0].find(".") < 0:
             filename = names[0] + ".yaml"

--- a/src/cfclient/ui/tabs/locopositioning_tab.py
+++ b/src/cfclient/ui/tabs/locopositioning_tab.py
@@ -481,7 +481,7 @@ class LocoPositioningTab(Tab, locopositioning_tab_class):
         self._lps_state = self.LOCO_MODE_UNKNOWN
         self._update_lps_state(self.LOCO_MODE_UNKNOWN)
 
-        self._anchor_position_dialog = AnchorPositionDialog(self)
+        self._anchor_position_dialog = AnchorPositionDialog(self, helper)
         self._configure_anchor_positions_button.setEnabled(False)
 
     def _do_when_checked(self, enabled, fkn, arg):


### PR DESCRIPTION
Add support for flashing decks from the boot loader dialog.

Initially for the lighthouse deck, but will also work for other decks that have FW in the future.

To simplify the user experience we will remove the possibility of flashing .bin files, only .zip files will be supported. Also all flashing targets will be used when flashing and option to chose flashing targets will be removed. The user should use developer functionality (make cload) to flash a single target. 

The flashing procedure will contain restart(s) in some cases. Since the boot loader dialog now also handles connections to the CF, we will remove the auto-reconnect feature to avoid and complications when re-booting.

Related issues:
* bitcraze/crazyflie-firmware#700
* bitcraze/crazyflie-release#7
* bitcraze/crazyflie-lib-python#209

