### PR TITLE
ParamTab: Gray out parameters on disconnect

### DIFF
--- a/src/cfclient/ui/tabs/LogTab.py
+++ b/src/cfclient/ui/tabs/LogTab.py
@@ -72,7 +72,10 @@ class LogTab(Tab, param_tab_class):
 
     @pyqtSlot('QString')
     def disconnected(self, linkname):
-        self.logTree.clear()
+        root = self.logTree.invisibleRootItem()
+        for i in range(root.childCount()):
+            item = root.child(i)
+            item.setFlags(Qt.NoItemFlags)
 
     @pyqtSlot(str)
     def connected(self, linkURI):


### PR DESCRIPTION
This is instead of removing all of them, so that you can still see parameters and logging variables when disconnected.

Closes #250
