### PR TITLE
Add functionality to set lighthouse system type

### DIFF
--- a/src/cfclient/ui/dialogs/basestation_mode_dialog.ui
+++ b/src/cfclient/ui/dialogs/basestation_mode_dialog.ui
@@ -27,7 +27,7 @@
           </font>
          </property>
          <property name="text">
-          <string>Lighthouse Basestation Configuration Tool</string>
+          <string>Lighthouse V2 Basestation Configuration Tool</string>
          </property>
         </widget>
        </item>

--- a/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
+++ b/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
@@ -63,12 +63,17 @@ class LighthouseSystemTypeDialog(QtWidgets.QWidget, lighthouse_system_widget_cla
 
         self._curr_type = 0
 
-    def showEvent(self, event):
-        self._curr_type = 0
+    def get_system_type(self):
+        system_type = self.VALUE_V2
 
         values = self._helper.cf.param.values
         if self.PARAM_NAME in values[self.PARAM_GROUP]:
-            self._curr_type = int(values[self.PARAM_GROUP][self.PARAM_NAME])
+            system_type = int(values[self.PARAM_GROUP][self.PARAM_NAME])
+
+        return system_type
+
+    def showEvent(self, event):
+        self._curr_type = self.get_system_type()
 
         if self._curr_type == self.VALUE_V1:
             self._radio_btn_v1.setChecked(True)

--- a/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
+++ b/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+#
+#     ||          ____  _ __
+#  +------+      / __ )(_) /_______________ _____  ___
+#  | 0xBC |     / __  / / __/ ___/ ___/ __ `/_  / / _ \
+#  +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
+#   ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
+#
+#  Copyright (C) 2021 Bitcraze AB
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software
+#  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+#  MA  02110-1301, USA.
+
+"""
+Dialog box used to change lighthouse system type. Used from the lighthouse tab.
+"""
+import logging
+
+import cfclient
+from PyQt5 import QtWidgets
+from PyQt5 import uic
+
+__author__ = 'Bitcraze AB'
+__all__ = ['LighthouseSystemTypeDialog']
+
+logger = logging.getLogger(__name__)
+
+(lighthouse_system_widget_class, connect_widget_base_class) = (
+    uic.loadUiType(
+        cfclient.module_path + '/ui/dialogs/lighthouse_system_type_dialog.ui')
+)
+
+
+class LighthouseSystemTypeDialog(QtWidgets.QWidget, lighthouse_system_widget_class):
+
+    PARAM_GROUP = 'lighthouse'
+    PARAM_NAME = 'systemType'
+
+    VALUE_V1 = 1
+    VALUE_V2 = 2
+
+    def __init__(self, helper, *args):
+        super(LighthouseSystemTypeDialog, self).__init__(*args)
+        self.setupUi(self)
+
+        self._helper = helper
+
+        self._close_button.clicked.connect(self.close)
+
+        self._radio_btn_v1.toggled.connect(self._type_toggled)
+        self._radio_btn_v2.toggled.connect(self._type_toggled)
+
+        self._curr_type = 0
+
+    def showEvent(self, event):
+        self._curr_type = 0
+
+        values = self._helper.cf.param.values
+        if self.PARAM_NAME in values[self.PARAM_GROUP]:
+            self._curr_type = int(values[self.PARAM_GROUP][self.PARAM_NAME])
+
+        if self._curr_type == self.VALUE_V1:
+            self._radio_btn_v1.setChecked(True)
+        elif self._curr_type == self.VALUE_V2:
+            self._radio_btn_v2.setChecked(True)
+
+    def _type_toggled(self, *args):
+        new_type = self.VALUE_V2
+
+        if self._radio_btn_v1.isChecked():
+            new_type = self.VALUE_V1
+        elif self._radio_btn_v2.isChecked():
+            new_type = self.VALUE_V2
+
+        if new_type != self._curr_type:
+            self._curr_type = new_type
+            self._helper.cf.param.set_value(self.PARAM_GROUP + '.' + self.PARAM_NAME, self._curr_type)

--- a/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.ui
+++ b/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.ui
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>280</width>
+    <height>252</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>System type</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_4">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_6">
+       <item>
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Note: Calibration and geometry data is lost if the system type is changed.</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>System type</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_2">
+            <item>
+             <widget class="QRadioButton" name="_radio_btn_v1">
+              <property name="text">
+               <string>Lighthouse V1</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QRadioButton" name="_radio_btn_v2">
+              <property name="text">
+               <string>Lighthouse V2</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_5">
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QPushButton" name="_close_button">
+         <property name="text">
+          <string>Close</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/cfclient/ui/tabs/lighthouse_tab.py
+++ b/src/cfclient/ui/tabs/lighthouse_tab.py
@@ -669,9 +669,10 @@ class LighthouseTab(Tab, lighthouse_tab_class):
 
     def _calibration_read_cb(self, calibs):
         # Got calibration data from the CF, we have the full system configuration
-        self._save_sys_config(self._lh_geos, calibs)
+        system_type = self._system_type_dialog.get_system_type()
+        self._save_sys_config(self._lh_geos, calibs, system_type)
 
-    def _save_sys_config(self, geos, calibs):
+    def _save_sys_config(self, geos, calibs, system_type):
         names = QFileDialog.getSaveFileName(self, 'Save file', self._helper.current_folder, "*.yaml;*.*")
 
         if names[0] == '':
@@ -684,4 +685,4 @@ class LighthouseTab(Tab, lighthouse_tab_class):
         else:
             filename = names[0]
 
-        LighthouseConfigFileManager.write(filename, geos, calibs)
+        LighthouseConfigFileManager.write(filename, geos=geos, calibs=calibs, system_type=system_type)

--- a/src/cfclient/ui/tabs/lighthouse_tab.py
+++ b/src/cfclient/ui/tabs/lighthouse_tab.py
@@ -47,6 +47,7 @@ from cflib.localization import LighthouseConfigFileManager
 
 from cfclient.ui.dialogs.lighthouse_bs_geometry_dialog import LighthouseBsGeometryDialog
 from cfclient.ui.dialogs.basestation_mode_dialog import LighthouseBsModeDialog
+from cfclient.ui.dialogs.lighthouse_system_type_dialog import LighthouseSystemTypeDialog
 
 from vispy import scene
 import numpy as np
@@ -350,8 +351,10 @@ class LighthouseTab(Tab, lighthouse_tab_class):
 
         self._basestation_geometry_dialog = LighthouseBsGeometryDialog(self)
         self._basestation_mode_dialog = LighthouseBsModeDialog(self)
+        self._system_type_dialog = LighthouseSystemTypeDialog(helper)
 
         self._manage_estimate_geometry_button.clicked.connect(self._show_basestation_geometry_dialog)
+        self._change_system_type_button.clicked.connect(lambda: self._system_type_dialog.show())
         self._manage_basestation_mode_button.clicked.connect(self._show_basestation_mode_dialog)
 
         self._load_sys_config_button.clicked.connect(self._load_sys_config_button_clicked)
@@ -542,6 +545,7 @@ class LighthouseTab(Tab, lighthouse_tab_class):
     def _update_ui(self):
         enabled = self._is_connected and self.is_lighthouse_deck_active
         self._manage_estimate_geometry_button.setEnabled(enabled)
+        self._change_system_type_button.setEnabled(enabled)
         self._load_sys_config_button.setEnabled(enabled)
         self._save_sys_config_button.setEnabled(enabled)
 

--- a/src/cfclient/ui/tabs/lighthouse_tab.ui
+++ b/src/cfclient/ui/tabs/lighthouse_tab.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1438</width>
+    <width>1753</width>
     <height>763</height>
    </rect>
   </property>
@@ -24,6 +24,9 @@
        <property name="spacing">
         <number>6</number>
        </property>
+       <property name="sizeConstraint">
+        <enum>QLayout::SetMinimumSize</enum>
+       </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_8">
          <property name="sizeConstraint">
@@ -38,6 +41,12 @@
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
              </property>
              <property name="title">
               <string>Crazyflie status</string>
@@ -173,6 +182,12 @@
                <horstretch>0</horstretch>
                <verstretch>0</verstretch>
               </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
              </property>
              <property name="title">
               <string>Basestation Status</string>
@@ -386,7 +401,7 @@
                         <property name="sizeHint" stdset="0">
                          <size>
                           <width>20</width>
-                          <height>10</height>
+                          <height>0</height>
                          </size>
                         </property>
                        </spacer>
@@ -414,8 +429,14 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
              <property name="title">
-              <string>Basestation Management</string>
+              <string>System Management</string>
              </property>
              <layout class="QVBoxLayout" name="verticalLayout">
               <item>
@@ -430,9 +451,16 @@
                    </widget>
                   </item>
                   <item>
+                   <widget class="QPushButton" name="_change_system_type_button">
+                    <property name="text">
+                     <string>Change system type</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QPushButton" name="_manage_basestation_mode_button">
                     <property name="text">
-                     <string>Set channel</string>
+                     <string>Set BS channel</string>
                     </property>
                    </widget>
                   </item>
@@ -464,7 +492,7 @@
                   <property name="sizeHint" stdset="0">
                    <size>
                     <width>20</width>
-                    <height>10</height>
+                    <height>0</height>
                    </size>
                   </property>
                  </spacer>
@@ -494,7 +522,11 @@
       </layout>
      </item>
      <item row="1" column="0">
-      <layout class="QVBoxLayout" name="_plot_layout"/>
+      <layout class="QVBoxLayout" name="_plot_layout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetDefaultConstraint</enum>
+       </property>
+      </layout>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
Add a dialog box to set lighthouse system type (V1 or V2)
When the system type is changed, the CF will erase geo and calib data and the client must update accordingly.

The system type is set through the lighthouse.systemType parameter.

Requires bitcraze/crazyflie-firmware#728 and bitcraze/crazyflie-lib-python#211