### PR TITLE
Remove pyproject.toml to get pip to install to user

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,0 @@
-[build-system]
-# Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel"]  # PEP 508 specifications.


### PR DESCRIPTION
When pyproject.toml is present, I cannot "pip install -e ." does not work since it refuses to install in the user folder. The only way to get it to work is to do ```pip3 install --user --no-use-pep517 -e .```.

Since we are not really needing pyproject.toml I propose to remove it. It would be nice to have (it makes pip build package in isolation), but it might not be worth it if it breaks development install.