### PR TITLE
Fix install from source

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ recursive-include src/cfclient/configs *.json
 recursive-include src/cfclient/ui *.ui
 recursive-include src/cfclient/resources *
 include src/cfclient/version.json
-include pyproject.toml
+include gitversion.py

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,10 @@ def relative(lst, base=''):
     return list(map(lambda x: base + os.path.basename(x), lst))
 
 
-VERSION = get_version()
+try:
+    VERSION = get_version()
+except Exception:
+    VERSION = None
 
 if not VERSION and not os.path.isfile('src/cfclient/version.json'):
     sys.stderr.write("Git is required to install from source.\n" +


### PR DESCRIPTION
This is the minimal change to fix install from souce.

The problem was that if we are not in a git repos, VERSION needs to be set to None and the version if found in a json file.

This still look a bit bad though. Maybe the version should be fetched from python instead. The release taball contains a file named `PKG-INFO`, it might be cleaner to get the version from there instead?