### PR TITLE
Console tab: new messages should always appear at the bottom

### DIFF
--- a/src/cfclient/ui/tabs/ConsoleTab.py
+++ b/src/cfclient/ui/tabs/ConsoleTab.py
@@ -33,6 +33,7 @@ import logging
 
 from PyQt5 import uic
 from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtGui import QTextCursor
 
 import cfclient
 from cfclient.ui.tab import Tab
@@ -88,7 +89,10 @@ class ConsoleTab(Tab, console_tab_class):
         # Make sure we get printouts from the Crazyflie into the log (such as
         # build version and test ok/fail)
         logger.debug("[%s]", text)
+        self.console.moveCursor(QTextCursor.End)
         self.console.insertPlainText(text)
+        scrollbar = self.console.verticalScrollBar()
+        scrollbar.setValue(scrollbar.maximum())
 
     def clear(self):
         self.console.clear()

--- a/src/cfclient/ui/tabs/ConsoleTab.py
+++ b/src/cfclient/ui/tabs/ConsoleTab.py
@@ -89,10 +89,19 @@ class ConsoleTab(Tab, console_tab_class):
         # Make sure we get printouts from the Crazyflie into the log (such as
         # build version and test ok/fail)
         logger.debug("[%s]", text)
+        scrollbar = self.console.verticalScrollBar()
+        prev_scroll = scrollbar.value()
+        was_maximum = prev_scroll == scrollbar.maximum()
+        prev_cursor = self.console.textCursor()
+
         self.console.moveCursor(QTextCursor.End)
         self.console.insertPlainText(text)
-        scrollbar = self.console.verticalScrollBar()
-        scrollbar.setValue(scrollbar.maximum())
+
+        if was_maximum:
+            scrollbar.setValue(scrollbar.maximum())
+        else:
+            self.console.setTextCursor(prev_cursor)
+            scrollbar.setValue(prev_scroll)
 
     def clear(self):
         self.console.clear()

--- a/src/cfclient/ui/tabs/ConsoleTab.py
+++ b/src/cfclient/ui/tabs/ConsoleTab.py
@@ -91,16 +91,17 @@ class ConsoleTab(Tab, console_tab_class):
         logger.debug("[%s]", text)
         scrollbar = self.console.verticalScrollBar()
         prev_scroll = scrollbar.value()
-        was_maximum = prev_scroll == scrollbar.maximum()
         prev_cursor = self.console.textCursor()
+        was_maximum = prev_scroll == scrollbar.maximum()
 
         self.console.moveCursor(QTextCursor.End)
         self.console.insertPlainText(text)
 
-        if was_maximum:
+        self.console.setTextCursor(prev_cursor)
+
+        if was_maximum and not prev_cursor.hasSelection():
             scrollbar.setValue(scrollbar.maximum())
         else:
-            self.console.setTextCursor(prev_cursor)
             scrollbar.setValue(prev_scroll)
 
     def clear(self):


### PR DESCRIPTION
When clicking inside the console view, new messages are written to the cursor position instead of the end of the widget. This PR appends the new messages to the end of the widget instead.

Additionally this scrolls to the bottom when the new logs are received, but if the widget is scrolled away from the end it is kept at the same position. This allow users to view and copy previous console messages while new messages appear.