### PR TITLE
Updated dead link

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -18,7 +18,7 @@ pip3 install --upgrade pip.
 ### Setting udev permissions
 
 Using Crazyradio on Linux requires that you set udev permissions. See the cflib
-[readme](https://github.com/bitcraze/crazyflie-lib-python#setting-udev-permissions)
+[installation guide](https://github.com/bitcraze/crazyflie-lib-python/blob/master/docs/installation/install.md#setting-udev-permissions)
 for more information.
 
 ## Windows


### PR DESCRIPTION
To find out more about udev permissions the reader got pointed to the README.md of the crazyflie-lib-python repo. However, the desired piece of information seems to have moved to the installation guide (install.md) in the mean time.