### PR TITLE
Use log_param_doc.json from crazyflie-firmware

### DIFF
--- a/.github/workflows/log-param-docs.yml
+++ b/.github/workflows/log-param-docs.yml
@@ -1,0 +1,43 @@
+name: Log- and param documentation
+
+# Controls when the action will run.
+on:
+  workflow_dispatch:
+  schedule:
+  - cron:  '0 0 * * *'
+
+jobs:
+  update_log_param_json:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out sources
+        uses: actions/checkout@v2
+
+      - name: Checkout crazyflie-firmware
+        uses: actions/checkout@v2
+        with:
+          repository: bitcraze/crazyflie-firmware
+          path: firmware
+
+      - name: Generate log_param_doc.json
+        run: |
+          cd firmware
+          docker run --rm -e "HOST_CW_DIR=${PWD}" \
+          -e "CALLING_HOST_NAME=$(hostname)" -e "CALLING_UID"=$UID \
+          -e "CALLING_OS"=$(uname) -v ${PWD}:/tb-module \
+          -v ${HOME}/.ssh:/root/.ssh \
+          -v /var/run/docker.sock:/var/run/docker.sock bitcraze/toolbelt \
+          build-docs
+
+      - name: Update client log_param_doc.json
+        run: |
+          cp firmware/docs/api/log_param_doc.json src/cfclient/resources/
+          git add src/cfclient/resources/log_param_doc.json
+          git commit -m "Update log_param_doc.json" || echo "Nothing to commit"
+
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ cache
 src/cfclient.egg-info/*
 src/cfclient/third_party/*
 version.json
+log_param_doc.json
 win32install/*.exe
 win32install/cfclient.nsi
 *.snap

--- a/src/cfclient/__init__.py
+++ b/src/cfclient/__init__.py
@@ -24,6 +24,7 @@
 #  this program; if not, write to the Free Software Foundation, Inc., 51
 #  Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+import json
 import os
 from appdirs import AppDirs
 import sys
@@ -43,6 +44,11 @@ if not hasattr(sys, 'frozen'):
     except pkg_resources.DistributionNotFound:
         VERSION = "dev"
 else:
-    import json
     with open(os.path.join(module_path, "version.json")) as f:
         VERSION = json.load(f)['version']
+
+try:
+    with open(os.path.join(module_path, "resources/log_param_doc.json")) as f:
+        log_param_doc = json.load(f)
+except:  # noqa
+    log_param_doc = None

--- a/src/cfclient/ui/tabs/LogTab.py
+++ b/src/cfclient/ui/tabs/LogTab.py
@@ -59,7 +59,10 @@ class LogTab(Tab, param_tab_class):
         self.cf = helper.cf
 
         # Init the tree widget
-        self.logTree.setHeaderLabels(['Name', 'ID', 'Unpack', 'Storage'])
+        self.logTree.setAlternatingRowColors(True)
+        self.logTree.setStyleSheet('QTreeWidget { alternate-background-color: #e9e9e9; }')
+        self.logTree.setHeaderLabels(['Name', 'ID', 'Unpack', 'Storage', 'Description'])
+        self.logTree.header().resizeSection(0, 150)
         self.logTree.setSortingEnabled(True)
         self.logTree.sortItems(0, Qt.AscendingOrder)
 
@@ -83,15 +86,34 @@ class LogTab(Tab, param_tab_class):
 
         toc = self.cf.log.toc
 
-        for group in list(toc.toc.keys()):
+        for row_idx, group in enumerate(list(toc.toc.keys())):
             groupItem = QtWidgets.QTreeWidgetItem()
             groupItem.setData(0, Qt.DisplayRole, group)
+
             for param in list(toc.toc[group].keys()):
                 item = QtWidgets.QTreeWidgetItem()
                 item.setData(0, Qt.DisplayRole, param)
                 item.setData(1, Qt.DisplayRole, toc.toc[group][param].ident)
                 item.setData(2, Qt.DisplayRole, toc.toc[group][param].pytype)
                 item.setData(3, Qt.DisplayRole, toc.toc[group][param].ctype)
+
+                if cfclient.log_param_doc is not None:
+                    try:
+                        log_groups = cfclient.log_param_doc['logs'][group]
+                        log_variable = log_groups['variables'][param]
+                        item.setData(4, Qt.DisplayRole, log_variable['short_desc'])
+                    except:  # noqa
+                        pass
+
                 groupItem.addChild(item)
 
             self.logTree.addTopLevelItem(groupItem)
+
+            if cfclient.log_param_doc is not None:
+                try:
+                    log_groups = cfclient.log_param_doc['logs'][group]
+                    label = QtWidgets.QLabel(log_groups['desc'])
+                    label.setWordWrap(True)
+                    self.logTree.setItemWidget(groupItem, 4, label)
+                except:  # noqa
+                    pass

--- a/src/cfclient/ui/tabs/logTab.ui
+++ b/src/cfclient/ui/tabs/logTab.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QTreeWidget" name="logTree">
      <property name="columnCount">
-      <number>4</number>
+      <number>5</number>
      </property>
      <attribute name="headerDefaultSectionSize">
       <number>100</number>


### PR DESCRIPTION
This PR makes use of the logging and parameter documentation in the `crazyflie-firmware` repository to generate descriptions for the log- param tabs.

If, and only if, the file `src/cfclient/resources/log_param_doc.json` is present, we will use it to display descriptions for logging- and parameter groups and parameters in the relevant tabs.

![log-toc-desc](https://user-images.githubusercontent.com/974401/125058836-f1292600-e0aa-11eb-84ca-b7661d3011d5.png)

This PR also adds a GitHub actions workflow to generate and update the JSON file each night.

Commits:
- Use log_param_doc.json to add descriptions
- workflows: Add workflow to update log_param_doc
