### PR TITLE
#518: Add libxcb-xinemara0 install req

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -9,13 +9,12 @@ page_id: install
 
 For <  Ubuntu 20.04 you will need to check first if which version your python is on and if you have 'python3' on your system.
 
-From a fresh Ubuntu 20.04 system, running the client form source requires git and pip. 
+From a fresh Ubuntu 20.04 system, running the client form source requires git, pip and a lib for the Qt GUI. 
 
 ```
-sudo apt install git python3-pip python3-pyqt5
+sudo apt install git python3-pip libxcb-xinerama0
 pip3 install --upgrade pip
 ```
-Since the pyqt5 package required for the cfclient does not install all the libraries, it will need to be installed seperately too, however this should be fixed in the future. See this [issue](https://github.com/bitcraze/crazyflie-clients-python/issues/518)
 
 ### Setting udev permissions
 

--- a/src/cfclient/gui.py
+++ b/src/cfclient/gui.py
@@ -165,6 +165,9 @@ def main():
     from PyQt5.QtWidgets import QApplication
     from PyQt5.QtGui import QIcon
 
+    if os.name == 'posix':
+        logger.info('If startup fails because of "xcb", install dependency with `sudo apt install libxcb-xinerama0`.')
+
     app = QApplication(sys.argv)
     app.setStyle("Fusion")
     from cfclient.utils.ui import UiUtils


### PR DESCRIPTION
A newly installed Ubuntu 20+ requires libxcb-xinemara0 to be installed manually in order for Qt to work.

I am investigating the possibility of printing a warning in the console as well.