### PR TITLE
setup.py: Widen tolerated numpy version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -139,7 +139,7 @@ setup(
                                           'PyYAML~=5.3',
                                           'quamash~=0.6.1',
                                           'qtm~=2.0.2',
-                                          'numpy~=1.19.2',
+                                          'numpy>=1.19.2,<1.24',
                                           'vispy~=0.6.6',
                                           'pyserial~=3.5'],
 


### PR DESCRIPTION
Parahprased from Github issue:

We have had a lot of random bug due to random dependency version over
the years so we are not so comfortable opening the versions too wide.
Numpy promise to keep function for two minor release with a warning,
so >=1.19.2,<1.24 should be safe!

Closes #526
