### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/development/zmq-server.md
+++ b/docs/development/zmq-server.md
@@ -259,7 +259,7 @@ Below is an example for creating a logging configuration and starting it. The co
 variables _pm.vbat_ and _stabilizer.roll_ that will be sent at 1 Hz. Data will be published to the [log socket](#log-socket).
 
 Each action for log configurations (create, start, stop, delete) will be broadcasted on the log data socket. Log
-data will also be boardcasted on the same socket.
+data will also be broadcasted on the same socket.
 
 
 First create the configuration:
@@ -460,7 +460,7 @@ For each update the variable name and value is sent.
 ## Connection socket
 
 This socket is used to broadcast changes in the connection state as events. Connecting the Crazyflie is a synchronous
-call to the [command socket](#command-socket) but for instance a lost connection will be asynchronous and boardcasted
+call to the [command socket](#command-socket) but for instance a lost connection will be asynchronous and broadcasted
 on this socket.
 
 Each event has a name and uri, there might also be an optional message. Note that disconnected is always sent no

--- a/docs/functional-areas/cfloader.md
+++ b/docs/functional-areas/cfloader.md
@@ -17,7 +17,7 @@ platform and start it again by pressing the power button for at least
 
 ## Programming Crazyflie from firmware projects
 
-When developping with the Crazyflie firmware projects, either
+When developing with the Crazyflie firmware projects, either
 [crazyflie-firmware](https://github.com/bitcraze/crazyflie-firmware) or
 [crazyflie2-nrf-firmware](https://github.com/bitcraze/crazyflie2-nrf-firmware)
 you can flash your current build with:
@@ -30,7 +30,7 @@ you can enable the warmboot mode. To do so, edit the file
 
     CLOAD_CMDS = -w radio://0/80/250K/E7E7E7E7E7
 
-After this, \'make cload\' will restart the Crazyflie in bootlader mode,
+After this, \'make cload\' will restart the Crazyflie in bootloader mode,
 flash it and restart it with the new firmware.
 
 In warmboot mode the bootloader is launched
@@ -39,7 +39,7 @@ programmed at the same time without collision.
 
 **Warning:** If the flashing operation fails or if
 the firmware has a bug, it may be impossible to warmboot. In that case
-start the bootloader manually and disable warmboot temporarly by
+start the bootloader manually and disable warmboot temporarily by
 programming with:
 
     make cload CLOAD_CMDS=

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -56,7 +56,7 @@ pip3 install --upgrade pip.
 
 # Installing from latest release
 
-If you are planning to not do any developement on the client itself, we highly recommend you to install the cfclient according to latest release (as according of the instructions described) and not from source ([from these instructions](#installing-from-source)). 
+If you are planning to not do any development on the client itself, we highly recommend you to install the cfclient according to latest release (as according of the instructions described) and not from source ([from these instructions](#installing-from-source)). 
 
 Make sure that you have installed the [prerequisites](#prerequisites-installation)!
 
@@ -100,7 +100,7 @@ $ pip3 -e .[dev]
 
 The client can now be runned using ```cfclient``` if the local pip bin directory is in the path (it should be in a venv or after a reboot), or with ```python3 -m cfclient.gui```.
 
-At the very least you should **never** run pip in sudo, this would install dependencies system wide and could cause compatiblity problems with already installed application. If the ```pip``` of ```python3 -m pip``` command request the administrator password, you should run the command with ```--user``` (for example ```python3 -m pip install --user -e .```). This should not be required on modern python distribution though since the *--user*  flag seems to be the default behaviour.
+At the very least you should **never** run pip in sudo, this would install dependencies system wide and could cause compatibility problems with already installed application. If the ```pip``` of ```python3 -m pip``` command request the administrator password, you should run the command with ```--user``` (for example ```python3 -m pip install --user -e .```). This should not be required on modern python distribution though since the *--user*  flag seems to be the default behaviour.
 
 ## Windows (7/8/10)
 

--- a/docs/userguides/recovery-mode.md
+++ b/docs/userguides/recovery-mode.md
@@ -27,7 +27,7 @@ To update the firmware in the Crazyflie 2.X do the following:
     power.
 -   Click \"Initiate bootloader cold boot\"
 -   Select the latest release from the drop down menu or select it if you have downloaded it from the [Github release page](https://github.com/bitcraze/crazyflie-release/releases).
--   Press \"Program\" and wait (do not restart the crazyflie untill it is finsished.)
+-   Press \"Program\" and wait (do not restart the crazyflie untill it is finished.)
 -   Press \"Restart in firmware mode\"
 
 _Be aware that the Lighthouse FPGA will not be updated in this mode, so please use the [the cfclient userguide](/docs/userguides/userguide_client/index.md) after you have recovered crazyflie._

--- a/docs/userguides/userguide_client/index.md
+++ b/docs/userguides/userguide_client/index.md
@@ -209,7 +209,7 @@ width="300"}
 
 Follow the instructions to detect the axis or button that you would like
 to map to the functionality. If you would like to map the functionality
-to two axis (like right/left sholder-button) then select *Combined axis
+to two axis (like right/left shoulder-button) then select *Combined axis
 detection* and follow the instructions.
 
 Go though all the functionality you would like to map by pressing the

--- a/docs/userguides/userguide_client/lighthouse_tab.md
+++ b/docs/userguides/userguide_client/lighthouse_tab.md
@@ -39,15 +39,15 @@ estimation process. When setting up the system work from left to right and make 
 
 1.  **Receiving** - green = light is received from the base station, red = no reception
 2.  **Calibration** - indicates if there is calibration data for the base station or not.
-    * Red = no calibration data, blue = calibration data from persistant storage but not yet confirmed
+    * Red = no calibration data, blue = calibration data from persistent storage but not yet confirmed
     * green = calibration data has been received from the base station and matched previous data
     * orange = calibration data has been received from the base station but did **not** match the previous data, this means that you probably should redo the geometry estimation.
 3. **Geometry** - indicates whether geometry data is available or not.
-    * Green = geometry data from persistant storage or has been set from the client
+    * Green = geometry data from persistent storage or has been set from the client
     * red = no geometry data.
     Note: it is possible that the geometry indicator is green even though the geometry data is not valid, this is for instance the case if a base station is moved in a stystem that has been set up earlier.
 4.  **Estimator** - data from the base station is sent to the estimator to be used in the position estimation process.
-    Note: when Calibration data is receievd it is automatically stored in the persistant memory to be available immediately after reboot.
+    Note: when Calibration data is received it is automatically stored in the persistent memory to be available immediately after reboot.
 
 ### System Management
 This section us used to configure the system.
@@ -57,7 +57,7 @@ This section us used to configure the system.
     orientation of the base stations, using the Crazyflie postition as the origin.
     The result is displayed together with the current geometry data. Click the
     **Write to Crazyflie** button to use the new geometry data, the new data is
-    also stored in the Crazyflie persistant storage to make it available after reboot.
+    also stored in the Crazyflie persistent storage to make it available after reboot.
 
 * **Change system type** - Opens a dialog box where the system type can be changed.
     Possible options are **Lighthouse V1** and **Lighthouse V2**.

--- a/src/cfclient/ui/dialogs/bootloader.py
+++ b/src/cfclient/ui/dialogs/bootloader.py
@@ -248,7 +248,7 @@ class BootloaderDialog(QtWidgets.QWidget, service_dialog_class):
                 self.firmwareDropdown.addItem(widget_name)
 
     def release_zip_downloaded(self, release_name, release_path):
-        """ Callback when a release is succesfully downloaded and
+        """ Callback when a release is successfully downloaded and
             save to release_path.
         """
         self.downloadStatus.setText('Downloaded')

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -723,8 +723,8 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
     def _inputconfig_selected(self, checked):
         """Called when a new configuration has been selected from the menu. The
-        data in the menu object is a referance to the device QAction in parent
-        menu. This contains a referance to the raw device."""
+        data in the menu object is a reference to the device QAction in parent
+        menu. This contains a reference to the raw device."""
         if not checked:
             return
 

--- a/src/cfclient/ui/tabs/QualisysTab.py
+++ b/src/cfclient/ui/tabs/QualisysTab.py
@@ -1259,7 +1259,7 @@ class QualisysTab(Tab, qualisys_tab_class):
                         self.switch_flight_mode(FlightModeStates.PATH)
 
                 elif self.flight_mode == FlightModeStates.GROUNDED:
-                    pass  # If gounded, the control is switched back to gamepad
+                    pass  # If grounded, the control is switched back to gamepad
 
                 time.sleep(0.001)
 

--- a/src/cfclient/ui/tabs/lighthouse_tab.py
+++ b/src/cfclient/ui/tabs/lighthouse_tab.py
@@ -629,7 +629,7 @@ class LighthouseTab(Tab, lighthouse_tab_class):
                 temp_set = self._bs_stats[stats_id]
 
                 if bs in temp_set:
-                    # If the status bar for calibration data is handled, have an intermeddiate status
+                    # If the status bar for calibration data is handled, have an intermediate status
                     # else just have red or green.
                     if stats_indicator_id == 2:
                         label.setStyleSheet(STYLE_BLUE_BACKGROUND)

--- a/src/cfclient/utils/input/__init__.py
+++ b/src/cfclient/utils/input/__init__.py
@@ -449,7 +449,7 @@ class JoystickReader(object):
                     vz = data.thrust
                     yawrate = data.yaw
                     # The odd use of vx and vy is to map forward on the
-                    # physical joystick to positiv X-axis
+                    # physical joystick to positive X-axis
                     self.assisted_input_updated.call(vy, -vx, vz, yawrate)
                 elif self._assisted_control == \
                         JoystickReader.ASSISTED_CONTROL_HOVER \
@@ -459,7 +459,7 @@ class JoystickReader(object):
 
                     # Scale thrust to a value between -1.0 to 1.0
                     vz = (data.thrust - 32767) / 32767.0
-                    # Integrate velosity setpoint
+                    # Integrate velocity setpoint
                     self._target_height += vz * INPUT_READ_PERIOD
                     # Cap target height
                     if self._target_height > self._hover_max_height:
@@ -469,7 +469,7 @@ class JoystickReader(object):
 
                     yawrate = data.yaw
                     # The odd use of vx and vy is to map forward on the
-                    # physical joystick to positiv X-axis
+                    # physical joystick to positive X-axis
                     self.hover_input_updated.call(vy, -vx, yawrate,
                                                   self._target_height)
                 else:
@@ -496,7 +496,7 @@ class JoystickReader(object):
                         yawrate = data.yaw
                         # Scale thrust to a value between -1.0 to 1.0
                         vz = (data.thrust - 32767) / 32767.0
-                        # Integrate velosity setpoint
+                        # Integrate velocity setpoint
                         self._target_height += vz * INPUT_READ_PERIOD
                         # Cap target height
                         if self._target_height > self._hover_max_height:


### PR DESCRIPTION
There are small typos in:
- docs/development/zmq-server.md
- docs/functional-areas/cfloader.md
- docs/installation/install.md
- docs/userguides/recovery-mode.md
- docs/userguides/userguide_client/index.md
- docs/userguides/userguide_client/lighthouse_tab.md
- src/cfclient/ui/dialogs/bootloader.py
- src/cfclient/ui/main.py
- src/cfclient/ui/tabs/QualisysTab.py
- src/cfclient/ui/tabs/lighthouse_tab.py
- src/cfclient/utils/input/__init__.py

Fixes:
- Should read `persistent` rather than `persistant`.
- Should read `velocity` rather than `velosity`.
- Should read `positive` rather than `positiv`.
- Should read `broadcasted` rather than `boardcasted`.
- Should read `temporarily` rather than `temporarly`.
- Should read `successfully` rather than `succesfully`.
- Should read `shoulder` rather than `sholder`.
- Should read `reference` rather than `referance`.
- Should read `received` rather than `receievd`.
- Should read `intermediate` rather than `intermeddiate`.
- Should read `grounded` rather than `gounded`.
- Should read `finished` rather than `finsished`.
- Should read `development` rather than `developement`.
- Should read `developing` rather than `developping`.
- Should read `compatibility` rather than `compatiblity`.
- Should read `bootloader` rather than `bootlader`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md