### PR TITLE
updated flightcommand buttons to gray out if controller is attached

### DIFF
--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -205,8 +205,6 @@ class FlightTab(Tab, flight_tab_class):
             lambda: self._flight_command(CommanderAction.DOWN)
         )
 
-        self.joystickReader = JoystickReader()
-
         self.uiSetupReady()
 
         self._led_ring_headlight.clicked.connect(
@@ -412,7 +410,7 @@ class FlightTab(Tab, flight_tab_class):
             return
 
         # To prevent conflicting commands from the controller and the flight panel
-        if len(self.joystickReader.available_devices()) > 0:
+        if JoystickReader().available_devices():
             self.commanderBox.setToolTip(
                 'Cant use both an controller and Command Based Flight'
             )

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -115,8 +115,6 @@ class FlightTab(Tab, flight_tab_class):
 
     _limiting_updated = pyqtSignal(bool, bool, bool)
 
-
-
     def __init__(self, tabWidget, helper, *args):
         super(FlightTab, self).__init__(*args)
         self.setupUi(self)
@@ -208,7 +206,6 @@ class FlightTab(Tab, flight_tab_class):
         )
 
         self.joystickReader = JoystickReader()
-
 
         self.uiSetupReady()
 
@@ -413,11 +410,12 @@ class FlightTab(Tab, flight_tab_class):
             )
             self.commanderBox.setEnabled(False)
             return
-        
+
         # To prevent conflicting commands from the controller and the flight panel
         if len(self.joystickReader.available_devices()) > 0:
             self.commanderBox.setToolTip(
-                'Cant use both a USB controller and Command Based Flight')
+                'Cant use both an controller and Command Based Flight'
+            )
             self.commanderBox.setEnabled(False)
             return
 

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -115,6 +115,8 @@ class FlightTab(Tab, flight_tab_class):
 
     _limiting_updated = pyqtSignal(bool, bool, bool)
 
+
+
     def __init__(self, tabWidget, helper, *args):
         super(FlightTab, self).__init__(*args)
         self.setupUi(self)
@@ -204,6 +206,9 @@ class FlightTab(Tab, flight_tab_class):
         self.commanderDownButton.clicked.connect(
             lambda: self._flight_command(CommanderAction.DOWN)
         )
+
+        self.joystickReader = JoystickReader()
+
 
         self.uiSetupReady()
 
@@ -407,6 +412,14 @@ class FlightTab(Tab, flight_tab_class):
                 'You need a positioning deck to use Command Based Flight'
             )
             self.commanderBox.setEnabled(False)
+            return
+        
+        # To prevent conflicting commands from the controller and the flight panel
+        if len(self.joystickReader.available_devices()) > 0:
+            self.commanderBox.setToolTip(
+                'Cant use both a USB controller and Command Based Flight')
+            self.commanderBox.setEnabled(False)
+            return
 
     def connected(self, linkURI):
         # MOTOR & THRUST


### PR DESCRIPTION
The flight command channel grays out if an controller is attached. This should fix #538, but it doesn't regularly update. 

Also currently this issue ( #541) is preventing me to try out anything in case the controller get's disconnected when the cfclient is still on. 