### PR TITLE
Bump dependencies to support Py3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,15 +77,6 @@ if sys.platform == 'win32' or sys.platform == 'darwin':
 if sys.platform == 'win32':
     platform_dev_requires.extend(['cx_freeze==5.1.1', 'jinja2==2.10.3'])
 
-# Only install the latest pyqt for Linux and Mac
-# On Windows, the latest version that does not have performance problems
-# is 5.12
-if sys.platform == 'win32':
-    platform_requires += ['pyqt5~=5.12.0']
-else:
-    platform_requires += ['pyqt5~=5.15.0']
-
-
 package_data = {
     'cfclient.ui':  relative(glob('src/cfclient/ui/*.ui')),
     'cfclient.ui.tabs': relative(glob('src/cfclient/ui/tabs/*.ui')),
@@ -134,14 +125,15 @@ setup(
 
     install_requires=platform_requires + ['cflib>=0.1.16',
                                           'appdirs~=1.4.0',
-                                          'pyzmq~=19.0',
+                                          'pyzmq~=22.3',
                                           'pyqtgraph~=0.11',
                                           'PyYAML~=5.3',
                                           'asyncqt~=0.8.0',
                                           'qtm~=2.0.2',
                                           'numpy>=1.19.2,<1.24',
-                                          'vispy~=0.6.6',
-                                          'pyserial~=3.5'],
+                                          'vispy~=0.9.0',
+                                          'pyserial~=3.5',
+                                          'pyqt5~=5.15.0'],
 
     # List of dev dependencies
     # You can install them by running


### PR DESCRIPTION
This PR fixes install on Windows with Python 3.10. It needs to be tested on all platform for older python as well.

This also bumps PyQT5 for Windows which, in the past, has had performance issues. It needs to be checked.

Fixes #549