### PR TITLE
Fix XB1 gamepad support on M1 Mac

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ else:
 platform_requires = []
 platform_dev_requires = ['pre-commit']
 if sys.platform == 'win32' or sys.platform == 'darwin':
-    platform_requires.extend(['pysdl2~=0.9.6', 'pysdl2-dll==2.0.14.post1'])
+    platform_requires.extend(['pysdl2~=0.9.6', 'pysdl2-dll==2.0.16'])
 if sys.platform == 'win32':
     platform_dev_requires.extend(['cx_freeze==5.1.1', 'jinja2==2.10.3'])
 


### PR DESCRIPTION
According to a [forum post](https://forum.bitcraze.io/viewtopic.php?p=23694#p23694) bumping the sdl version to 2.0.16 helps for XB1 gamepad support on MacOS on M1.

I cannot verify that since I do not have an XB1 gamepad at hands, but I could verify that bumping the SDL version did not hurt.