### PR TITLE
Fix Color picker on LED-tab not working

### DIFF
--- a/src/cfclient/ui/tabs/LEDTab.py
+++ b/src/cfclient/ui/tabs/LEDTab.py
@@ -34,7 +34,7 @@ import logging
 
 from PyQt5 import QtGui, uic
 from PyQt5.QtCore import pyqtSignal
-from PyQt5 import QtWidgets;
+from PyQt5 import QtWidgets
 
 import cfclient
 from cfclient.ui.tab import Tab

--- a/src/cfclient/ui/tabs/LEDTab.py
+++ b/src/cfclient/ui/tabs/LEDTab.py
@@ -34,6 +34,7 @@ import logging
 
 from PyQt5 import QtGui, uic
 from PyQt5.QtCore import pyqtSignal
+from PyQt5 import QtWidgets;
 
 import cfclient
 from cfclient.ui.tab import Tab
@@ -121,7 +122,7 @@ class LEDTab(Tab, led_tab_class):
             led = self._mem.leds[nbr]
             col = QtGui.QColor.fromRgb(led.r, led.g, led.b)
 
-        col = QtGui.QColorDialog.getColor(col)
+        col = QtWidgets.QColorDialog.getColor(col)
 
         if col.isValid() and self._mem:
             logger.info(col.red())


### PR DESCRIPTION
The problem was caused by the code calling a Qt4-style API instead of Qt5.

This showed when running in a venv.

Fixes #555