### PR TITLE
Remove Windows CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,46 +35,5 @@ jobs:
 
       - name: CI checks
         run: docker run --rm -v ${PWD}:/module bitcraze/builder ./tools/build/build
-  
-  Windows:
-    name: Windows
-    needs: checks
 
-    runs-on: windows-2019
-
-    steps:
-      # Checkout, fetch-depth=0 fetches the full repos (required for automatic versioning to work)
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      
-      - name: Set up Python 3.6
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
-          architecture: 'x86'
-
-      - name: Install dependencies
-        run: |
-          pip install -e .[dev,qt5]
-      
-      - name: Install nsis
-        run: choco install -y nsis.portable -version 2.50
-
-      - name: Build exe
-        run: python setup.py install_exe -d windows_build
-      
-      - name: Test exe
-        run: windows_build\cfclient.exe --check-imports
-      
-      - name: Build installer
-        run: |
-          python win32install\generate_nsis.py
-          makensis win32install\cfclient.nsi
-      
-      - name: Upload Build Artifact
-        uses: actions/upload-artifact@v2.1.4
-        with:
-          name: windows-build
-          path: "win32install/*.exe"
 


### PR DESCRIPTION
The Windows build has not been functional for years and now the CI
starts failing because of dependencies.

Remove the Windows CI for now, it can be added back when (if) we fix the
windows .exe build.