### PR TITLE
fix parsing xml qtm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
                                           'pyqtgraph~=0.11',
                                           'PyYAML~=5.3',
                                           'asyncqt~=0.8.0',
-                                          'qtm~=2.0.2',
+                                          'qtm~=2.1.1',
                                           'numpy>=1.20,<1.25',
                                           'vispy~=0.9.0',
                                           'pyserial~=3.5',

--- a/src/cfclient/ui/tabs/QualisysTab.py
+++ b/src/cfclient/ui/tabs/QualisysTab.py
@@ -798,7 +798,7 @@ class QualisysTab(Tab, qualisys_tab_class):
 
             # Parse the returned xml
             xml = ET.fromstring(result)
-            self.qtm_6DoF_labels = [label.text for label in xml.iter('Name')]
+            self.qtm_6DoF_labels = [label.text.strip() for index, label in enumerate(xml.findall("*/Body/Name"))]
 
             # Make all names lowercase
             self.qtm_6DoF_labels = [x.lower() for x in self.qtm_6DoF_labels]

--- a/src/cfclient/ui/tabs/QualisysTab.py
+++ b/src/cfclient/ui/tabs/QualisysTab.py
@@ -798,7 +798,7 @@ class QualisysTab(Tab, qualisys_tab_class):
 
             # Parse the returned xml
             xml = ET.fromstring(result)
-            self.qtm_6DoF_labels = [label.text.strip() for index, label in enumerate(xml.findall("*/Body/Name"))]
+            self.qtm_6DoF_labels = [label.text.strip() for index, label in enumerate(xml.findall('*/Body/Name'))]
 
             # Make all names lowercase
             self.qtm_6DoF_labels = [x.lower() for x in self.qtm_6DoF_labels]


### PR DESCRIPTION
The new QTM software sends the xml file with the labels of the crazyflie in a different format as before. This causes the label array to intermittendly have a 'none' in between the actual rigid body labels.

 This PR changes that line that reads it out the xml to get all the rigid body labels and bumps up the qtm python library as well.