### PR TITLE
ParamTab: Catch error from param.set_value()

### DIFF
--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -354,7 +354,11 @@ class ParamTab(Tab, param_tab_class):
     def _set_param_value(self):
         name = self.paramDetailsLabel.text()
         value = self.currentValue.text()
-        self.cf.param.set_value(name, value)
+        try:
+            self.cf.param.set_value(name, value)
+            self.currentValue.setStyleSheet("border: none")
+        except Exception:
+            self.currentValue.setStyleSheet("border: 1px solid red")
 
     def _paramChanged(self):
         indexes = self.paramTree.selectionModel().selectedIndexes()
@@ -390,6 +394,7 @@ class ParamTab(Tab, param_tab_class):
             elem = self.cf.param.toc.get_element_by_complete_name(complete)
             value = round_if_float(self.cf.param.get_value(complete))
             self.currentValue.setText(value)
+            self.currentValue.setStyleSheet("border: none")
             self.currentValue.setCursorPosition(0)
             self.defaultValue.setText('-')
             self.cf.param.get_default_value(complete, lambda _, value: self._param_default_signal.emit(value))


### PR DESCRIPTION
So we can detect invalid parameter values without crash.

Fixes: #572
