### PR TITLE
added upgraded sip qt to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ else:
 platform_requires = []
 platform_dev_requires = ['pre-commit']
 if sys.platform == 'win32' or sys.platform == 'darwin':
-    platform_requires.extend(['pysdl2~=0.9.6', 'pysdl2-dll==2.0.16'])
+    platform_requires.extend(['pysdl2~=0.9.6', 'pysdl2-dll==2.0.16', 'sip==6.5.0', 'PyQt5-sip==12.9.0'])
 if sys.platform == 'win32':
     platform_dev_requires.extend(['cx_freeze==5.1.1', 'jinja2==2.10.3'])
 

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ else:
 platform_requires = []
 platform_dev_requires = ['pre-commit']
 if sys.platform == 'win32' or sys.platform == 'darwin':
-    platform_requires.extend(['pysdl2~=0.9.6', 'pysdl2-dll==2.0.16', 'sip==6.5.0', 'PyQt5-sip==12.9.0'])
+    platform_requires.extend(['pysdl2~=0.9.6', 'pysdl2-dll==2.0.16'])
 if sys.platform == 'win32':
     platform_dev_requires.extend(['cx_freeze==5.1.1', 'jinja2==2.10.3'])
 
@@ -133,7 +133,8 @@ setup(
                                           'numpy>=1.20,<1.25',
                                           'vispy~=0.9.0',
                                           'pyserial~=3.5',
-                                          'pyqt5~=5.15.0'],
+                                          'pyqt5~=5.15.0',
+                                          'PyQt5-sip>=12.9.0'],
 
     # List of dev dependencies
     # You can install them by running


### PR DESCRIPTION
This fixes the error I had when opening the client in latest version:
```
PS C:\Users\kimbe\Documents\Development\python\crazyflie-lib-python> cfclient
Traceback (most recent call last):
  File "C:\Python38\Scripts\cfclient-script.py", line 33, in <module>
    sys.exit(load_entry_point('cfclient', 'console_scripts', 'cfclient')())
  File "C:\Python38\Scripts\cfclient-script.py", line 25, in importlib_load_entry_point
    return next(matches).load()
  File "c:\python38\lib\importlib\metadata.py", line 77, in load
    module = import_module(match.group('module'))
  File "c:\python38\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "c:\users\kimbe\documents\development\python\crazyflie-clients-python\src\cfclient\gui.py", line 39, in <module>
    from asyncqt import QEventLoop
  File "c:\python38\lib\site-packages\asyncqt\__init__.py", line 60, in <module>
    QtCore = importlib.import_module(QtModuleName + '.QtCore', package=QtModuleName)
  File "c:\python38\lib\importlib\__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
RuntimeError: the sip module implements API v12.0 to v12.8 but the PyQt5.QtCore module requires API v12.9
```

After I updated the following: 
```
pip install PyQt5-sip --upgrade
pip install sip --upgrade
```
it all went better again. So I updated setup.py to contain:

- sip-6.5.0
- PyQt5-sip-12.9.0

