### PR TITLE
Set empty param description if no description is found

### DIFF
--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -386,7 +386,7 @@ class ParamTab(Tab, param_tab_class):
                 self.paramDetailsDescription.setWordWrap(True)
                 self.paramDetailsDescription.setText(desc.replace('\n', ''))
             except:  # noqa
-                pass
+                self.paramDetailsDescription.setText('')
 
         self.valueFrame.setVisible(param is not None)
         if param:


### PR DESCRIPTION
If no parameter description is found, the text in the parameter description box is left unchanged. If it was already set (by looking at another parameter) the old description will still be displayed. 

This PR clears the box in the case when no description is found. 

Related to #585