### PR TITLE
Added assert dump button

### DIFF
--- a/src/cfclient/ui/tabs/consoleTab.ui
+++ b/src/cfclient/ui/tabs/consoleTab.ui
@@ -42,6 +42,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="_dumpAssertInformation">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Assert info</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <widget class="QPushButton" name="_propellerTestButton">
          <property name="enabled">
           <bool>false</bool>


### PR DESCRIPTION
Added a button to the console log tab to trigger a dump of assert information.

Paired with bitcraze/crazyflie-firmware#1027