### PR TITLE
Use int for QProgressBar.setValue()

### DIFF
--- a/src/cfclient/ui/dialogs/bootloader.py
+++ b/src/cfclient/ui/dialogs/bootloader.py
@@ -343,7 +343,7 @@ class BootloaderDialog(QtWidgets.QWidget, service_dialog_class):
         logger.debug("Status: [%s] | %d", status, progress)
         self.statusLabel.setText('Status: <b>' + status + '</b>')
         if progress >= 0:
-            self.progressBar.setValue(progress)
+            self.progressBar.setValue(int(progress))
 
     def initiateColdboot(self):
         self.clt.initiateColdBootSignal.emit("radio://0/100")

--- a/src/cfclient/ui/dialogs/logconfigdialogue.py
+++ b/src/cfclient/ui/dialogs/logconfigdialogue.py
@@ -402,13 +402,13 @@ class LogConfigDialogue(QtWidgets.QWidget, logconfig_widget_class):
         if self.currentSize > MAX_LOG_SIZE:
             self.packetSize.setMaximum(self.currentSize / MAX_LOG_SIZE * 100)
             self.packetSize.setFormat("%v%")
-            self.packetSize.setValue(self.currentSize / MAX_LOG_SIZE * 100)
+            self.packetSize.setValue(int(self.currentSize / MAX_LOG_SIZE * 100))
             self.packetSize.setStyleSheet(
                         UiUtils.progressbar_stylesheet('red'))
         else:
             self.packetSize.setMaximum(MAX_LOG_SIZE)
             self.packetSize.setFormat("%p%")
-            self.packetSize.setValue(self.currentSize)
+            self.packetSize.setValue(int(self.currentSize))
             self.packetSize.setStyleSheet(
                         UiUtils.progressbar_stylesheet(UiUtils.COLOR_GREEN))
 

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -106,7 +106,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
     connectionDoneSignal = pyqtSignal(str)
     connectionFailedSignal = pyqtSignal(str, str)
     disconnectedSignal = pyqtSignal(str)
-    linkQualitySignal = pyqtSignal(int)
+    linkQualitySignal = pyqtSignal(float)
 
     _input_device_error_signal = pyqtSignal(str)
     _input_discovery_signal = pyqtSignal(object)
@@ -234,7 +234,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         # Connect link quality feedback
         self.cf.link_quality_updated.add_callback(self.linkQualitySignal.emit)
         self.linkQualitySignal.connect(
-            lambda percentage: self.linkQualityBar.setValue(percentage))
+            lambda percentage: self.linkQualityBar.setValue(int(percentage)))
 
         # Parse the log configuration files
         self.logConfigReader = LogConfigReader(self.cf)

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -551,7 +551,7 @@ class FlightTab(Tab, flight_tab_class):
         self.targetYaw.setText(("%0.2f deg/s" % yaw))
         self.targetThrust.setText(("%0.2f %%" %
                                    self.thrustToPercentage(thrust)))
-        self.thrustProgress.setValue(thrust)
+        self.thrustProgress.setValue(int(thrust))
 
         self._change_input_labels(using_hover_assist=False)
 


### PR DESCRIPTION
It seems as the setValue() method of QProgressBar only supports ints in the latest version of Qt(!).

This PR makes sure the values in calls to the method  are ints.

Fixes #595