### PR TITLE
fix unexpected type issue

### DIFF
--- a/src/cfclient/ui/dialogs/inputconfigdialogue.py
+++ b/src/cfclient/ui/dialogs/inputconfigdialogue.py
@@ -295,7 +295,7 @@ class InputConfigDialogue(QtWidgets.QWidget, inputconfig_widget_class):
                     scaled_value = InputConfigDialogue._scale(
                         self._input.max_yaw_rate, scaled_value
                     )
-                self._axisindicators[v].setValue(scaled_value)
+                self._axisindicators[v].setValue(int(scaled_value))
 
     def _map_axis(self, function, key_id, scale):
         self._map["Input.AXIS-{}".format(key_id)] = {}


### PR DESCRIPTION
When opening the input dialog for controllers, the terminal was giving the following issue:

```
===== 2022.05.11 12:05:15 =====   
Traceback (most recent call last):
File "c:\users\kimbe\development\bitcraze\python\crazyflie-clients-python\src\cfclient\ui\dialogs\inputconfigdialogue.py", line 298, in _update_mapped_values
self._axisindicators[v].setValue(scaled_value)
TypeError: setValue(self, int): argument 1 has unexpected type 'float'
```

This PR fixes that issue but determining it is an int, as it indicates a percentage in the range of a 100