### PR TITLE
hide labels based on basestation availability 

### DIFF
--- a/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
+++ b/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
@@ -50,23 +50,18 @@ class LighthouseSystemTypeDialog(QtWidgets.QWidget, lighthouse_system_widget_cla
     VALUE_V1 = 1
     VALUE_V2 = 2
 
-    def __init__(self, helper, ready_cb, *args):
+    def __init__(self, helper, *args):
         super(LighthouseSystemTypeDialog, self).__init__(*args)
         self.setupUi(self)
-        self.ready_cb = ready_cb
 
         self._helper = helper
 
-        self._close_button.clicked.connect(self.close_button_clicked)
+        self._close_button.clicked.connect(self.close)
 
         self._radio_btn_v1.toggled.connect(self._type_toggled)
         self._radio_btn_v2.toggled.connect(self._type_toggled)
 
         self._curr_type = 0
-
-    def close_button_clicked(self):
-        self.ready_cb(True)
-        self.close()
 
     def get_system_type(self):
         system_type = self.VALUE_V2

--- a/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
+++ b/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
@@ -96,6 +96,3 @@ class LighthouseSystemTypeDialog(QtWidgets.QWidget, lighthouse_system_widget_cla
         if new_type != self._curr_type:
             self._curr_type = new_type
             self._helper.cf.param.set_value(self.PARAM_GROUP + '.' + self.PARAM_NAME, self._curr_type)
-
-
-        

--- a/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
+++ b/src/cfclient/ui/dialogs/lighthouse_system_type_dialog.py
@@ -50,18 +50,23 @@ class LighthouseSystemTypeDialog(QtWidgets.QWidget, lighthouse_system_widget_cla
     VALUE_V1 = 1
     VALUE_V2 = 2
 
-    def __init__(self, helper, *args):
+    def __init__(self, helper, ready_cb, *args):
         super(LighthouseSystemTypeDialog, self).__init__(*args)
         self.setupUi(self)
+        self.ready_cb = ready_cb
 
         self._helper = helper
 
-        self._close_button.clicked.connect(self.close)
+        self._close_button.clicked.connect(self.close_button_clicked)
 
         self._radio_btn_v1.toggled.connect(self._type_toggled)
         self._radio_btn_v2.toggled.connect(self._type_toggled)
 
         self._curr_type = 0
+
+    def close_button_clicked(self):
+        self.ready_cb(True)
+        self.close()
 
     def get_system_type(self):
         system_type = self.VALUE_V2
@@ -91,3 +96,6 @@ class LighthouseSystemTypeDialog(QtWidgets.QWidget, lighthouse_system_widget_cla
         if new_type != self._curr_type:
             self._curr_type = new_type
             self._helper.cf.param.set_value(self.PARAM_GROUP + '.' + self.PARAM_NAME, self._curr_type)
+
+
+        

--- a/src/cfclient/ui/tabs/lighthouse_tab.py
+++ b/src/cfclient/ui/tabs/lighthouse_tab.py
@@ -289,7 +289,6 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
     _new_system_config_written_to_cf_signal = pyqtSignal(bool)
     _geometry_read_signal = pyqtSignal(object)
     _calibration_read_signal = pyqtSignal(object)
-    _system_type_changed_signal = pyqtSignal(object)
 
     def __init__(self, helper):
         super(LighthouseTab, self).__init__(helper, 'Lighthouse Positioning')
@@ -304,7 +303,6 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
         self._new_system_config_written_to_cf_signal.connect(self._new_system_config_written_to_cf)
         self._geometry_read_signal.connect(self._geometry_read_cb)
         self._calibration_read_signal.connect(self._calibration_read_cb)
-        self._system_type_changed_signal.connect(self._system_type_changed_cb)
 
         # Connect the Crazyflie API callbacks to the signals
         self._helper.cf.connected.add_callback(self._connected_signal.emit)
@@ -347,7 +345,7 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
 
         self._basestation_geometry_dialog = LighthouseBsGeometryDialog(self)
         self._basestation_mode_dialog = LighthouseBsModeDialog(self)
-        self._system_type_dialog = LighthouseSystemTypeDialog(helper, self._system_type_changed_signal.emit)
+        self._system_type_dialog = LighthouseSystemTypeDialog(helper)
 
         self._manage_estimate_geometry_button.clicked.connect(self._show_basestation_geometry_dialog)
         self._change_system_type_button.clicked.connect(lambda: self._system_type_dialog.show())
@@ -429,9 +427,6 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
         self._lh_geos = dict(filter(lambda key_value: key_value[1].valid, geometries.items()))
         self._basestation_geometry_dialog.geometry_updated(self._lh_geos)
         self._is_geometry_read_ongoing = False
-
-    def _system_type_changed_cb(self):
-        self._update_basestation_status_indicators()
 
     def _is_matching_current_geo_data(self, geometries):
         return geometries == self._lh_geos.keys()

--- a/src/cfclient/ui/tabs/lighthouse_tab.py
+++ b/src/cfclient/ui/tabs/lighthouse_tab.py
@@ -291,7 +291,6 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
     _calibration_read_signal = pyqtSignal(object)
     _system_type_changed_signal = pyqtSignal(object)
 
-
     def __init__(self, helper):
         super(LighthouseTab, self).__init__(helper, 'Lighthouse Positioning')
         self.setupUi(self)
@@ -611,7 +610,6 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
             container.addWidget(self._create_label(str(bs + 1)), 0, bs + 1)
             for i in range(1, 5):
                 container.addWidget(self._create_label(), i, bs + 1)
-
 
     def _mask_status_matrix(self, bs_available_mask):
         container = self._basestation_stats_container

--- a/src/cfclient/ui/tabs/lighthouse_tab.py
+++ b/src/cfclient/ui/tabs/lighthouse_tab.py
@@ -414,14 +414,7 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
             except AttributeError as e:
                 logger.warning(str(e))
 
-            try:
-                bs_available_mask = int(self._helper.cf.param.get_value('lighthouse.bsAvailable'))
-            except KeyError as e:
-                # Old firmware that does not support lighthouse.bsAvailable, set to bs 1 and 2 for backwards
-                # compatibility
-                bs_available_mask = 0x3
-                logger.warning(str(e))
-            self._populate_status_matrix(bs_available_mask)
+            self._populate_status_matrix()
 
             # Now that we know we have a lighthouse deck, setup the memory helper and config writer
             self._lh_memory_helper = LighthouseMemHelper(self._helper.cf)
@@ -609,15 +602,12 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
 
         return np.array(r)
 
-    def _populate_status_matrix(self, bs_available_mask):
+    def _populate_status_matrix(self):
         container = self._basestation_stats_container
 
         # Find the nr of base stations by looking for the highest bit that is set
         # Assume all bs up to that bit are available
         for bs in range(0, 16):
-            if bs_available_mask & (1 << bs) == 0:
-                break
-
             container.addWidget(self._create_label(str(bs + 1)), 0, bs + 1)
             for i in range(1, 5):
                 container.addWidget(self._create_label(), i, bs + 1)


### PR DESCRIPTION
This functionality is currently hiding basestations based on the basestationavailability coming from the crazyflie.

This is connected to this PR: https://github.com/bitcraze/crazyflie-firmware/pull/1092

This if now a read-only param but we will need to change it to an logging variable instead.