### PR TITLE
Check opencv install in LighthouseBsGeoEstimator

### DIFF
--- a/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.py
+++ b/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.py
@@ -138,7 +138,11 @@ class LighthouseBsGeometryDialog(QtWidgets.QWidget, basestation_geometry_widget_
         self._lighthouse_tab = lighthouse_tab
 
         self._estimate_geometry_button.clicked.connect(self._estimate_geometry_button_clicked)
-        self._estimate_geometry_opencv_button.clicked.connect(self._estimate_geometry_opencv_button_clicked)
+        self._opencv_estimator = LighthouseBsGeoEstimator()
+        if self._opencv_estimator.lighthouse_bs_geo_estimator_available():
+            self._estimate_geometry_opencv_button.clicked.connect(self._estimate_geometry_opencv_button_clicked)
+        else:
+            self._estimate_geometry_opencv_button.setEnabled(False)
         self._write_to_cf_button.clicked.connect(self._write_to_cf_button_clicked)
 
         self._sweep_angles_received_and_averaged_signal.connect(self._sweep_angles_received_and_averaged_cb)
@@ -150,6 +154,7 @@ class LighthouseBsGeometryDialog(QtWidgets.QWidget, basestation_geometry_widget_
 
         self._base_station_geometry_wizard = LighthouseBasestationGeometryWizard(
             self._lighthouse_tab._helper.cf, self._base_station_geometery_received_signal.emit)
+
 
         self._lh_geos = None
         self._newly_estimated_geometry = {}
@@ -180,12 +185,11 @@ class LighthouseBsGeometryDialog(QtWidgets.QWidget, basestation_geometry_widget_
 
     def _sweep_angles_received_and_averaged_cb(self, averaged_angles):
         self._averaged_angles = averaged_angles
-        estimator = LighthouseBsGeoEstimator()
         self._newly_estimated_geometry = {}
 
         for id, average_data in averaged_angles.items():
             sensor_data = average_data[1]
-            rotation_bs_matrix, position_bs_vector = estimator.estimate_geometry(sensor_data)
+            rotation_bs_matrix, position_bs_vector = self._opencv_estimator.estimate_geometry(sensor_data)
             geo = LighthouseBsGeometry()
             geo.rotation_matrix = rotation_bs_matrix
             geo.origin = position_bs_vector

--- a/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.py
+++ b/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.py
@@ -138,11 +138,11 @@ class LighthouseBsGeometryDialog(QtWidgets.QWidget, basestation_geometry_widget_
         self._lighthouse_tab = lighthouse_tab
 
         self._estimate_geometry_button.clicked.connect(self._estimate_geometry_button_clicked)
-        self._opencv_estimator = LighthouseBsGeoEstimator()
-        self._estimate_geometry_opencv_button.clicked.connect(self._estimate_geometry_opencv_button_clicked)
+        self._simple_estimator = LighthouseBsGeoEstimator()
+        self._estimate_geometry_simple_button.clicked.connect(self._estimate_geometry_simple_button_clicked)
         try:
-            if not self._opencv_estimator.is_lighthouse_bs_geo_estimator_available():
-                self._estimate_geometry_opencv_button.setEnabled(False)
+            if not self._simple_estimator.is_available():
+                self._estimate_geometry_simple_button.setEnabled(False)
         except Exception as e:
             print(e)
 
@@ -191,7 +191,7 @@ class LighthouseBsGeometryDialog(QtWidgets.QWidget, basestation_geometry_widget_
 
         for id, average_data in averaged_angles.items():
             sensor_data = average_data[1]
-            rotation_bs_matrix, position_bs_vector = self._opencv_estimator.estimate_geometry(sensor_data)
+            rotation_bs_matrix, position_bs_vector = self._simple_estimator.estimate_geometry(sensor_data)
             geo = LighthouseBsGeometry()
             geo.rotation_matrix = rotation_bs_matrix
             geo.origin = position_bs_vector
@@ -205,7 +205,7 @@ class LighthouseBsGeometryDialog(QtWidgets.QWidget, basestation_geometry_widget_
         self._base_station_geometry_wizard.show()
         self.hide()
 
-    def _estimate_geometry_opencv_button_clicked(self):
+    def _estimate_geometry_simple_button_clicked(self):
         self._sweep_angle_reader.start_angle_collection()
         self._update_ui()
 

--- a/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.py
+++ b/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.py
@@ -139,10 +139,13 @@ class LighthouseBsGeometryDialog(QtWidgets.QWidget, basestation_geometry_widget_
 
         self._estimate_geometry_button.clicked.connect(self._estimate_geometry_button_clicked)
         self._opencv_estimator = LighthouseBsGeoEstimator()
-        if self._opencv_estimator.lighthouse_bs_geo_estimator_available():
-            self._estimate_geometry_opencv_button.clicked.connect(self._estimate_geometry_opencv_button_clicked)
-        else:
-            self._estimate_geometry_opencv_button.setEnabled(False)
+        self._estimate_geometry_opencv_button.clicked.connect(self._estimate_geometry_opencv_button_clicked)
+        try:
+            if not self._opencv_estimator.is_lighthouse_bs_geo_estimator_available():
+                self._estimate_geometry_opencv_button.setEnabled(False)
+        except Exception as e:
+            print(e)  
+
         self._write_to_cf_button.clicked.connect(self._write_to_cf_button_clicked)
 
         self._sweep_angles_received_and_averaged_signal.connect(self._sweep_angles_received_and_averaged_cb)

--- a/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.py
+++ b/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.py
@@ -144,7 +144,7 @@ class LighthouseBsGeometryDialog(QtWidgets.QWidget, basestation_geometry_widget_
             if not self._opencv_estimator.is_lighthouse_bs_geo_estimator_available():
                 self._estimate_geometry_opencv_button.setEnabled(False)
         except Exception as e:
-            print(e)  
+            print(e)
 
         self._write_to_cf_button.clicked.connect(self._write_to_cf_button_clicked)
 
@@ -157,7 +157,6 @@ class LighthouseBsGeometryDialog(QtWidgets.QWidget, basestation_geometry_widget_
 
         self._base_station_geometry_wizard = LighthouseBasestationGeometryWizard(
             self._lighthouse_tab._helper.cf, self._base_station_geometery_received_signal.emit)
-
 
         self._lh_geos = None
         self._newly_estimated_geometry = {}

--- a/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.ui
+++ b/src/cfclient/ui/dialogs/lighthouse_bs_geometry_dialog.ui
@@ -42,9 +42,9 @@
         </spacer>
        </item>
        <item>
-        <widget class="QPushButton" name="_estimate_geometry_opencv_button">
+        <widget class="QPushButton" name="_estimate_geometry_simple_button">
          <property name="text">
-          <string>Estimate Geometry OpenCV</string>
+          <string>Estimate Geometry Simple</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
This checks if the opencv library is installed according to the cflib. This goes together with this PR https://github.com/bitcraze/crazyflie-lib-python/pull/353

Behavior:
Newest CFlib (from PR) + cfclient (this pr): the button opencv geo estimator is grayed out by default
older cflib (latest release or before this pr) + cfclient (this pr):  Exception when trying out opencv based estimator
newest cflib (from pr) + cfclient latest release or before  pr):  Exception when trying out opencv based estimator