### PR TITLE
Add support for storage statistics

### DIFF
--- a/src/cfclient/ui/tabs/ConsoleTab.py
+++ b/src/cfclient/ui/tabs/ConsoleTab.py
@@ -84,6 +84,9 @@ class ConsoleTab(TabToolbox, console_tab_class):
         self._batteryTestButton.clicked.connect(
             lambda enabled:
             self._helper.cf.param.set_value("health.startBatTest", '1'))
+        self._storageStatsButton.clicked.connect(
+            lambda enabled:
+            self._helper.cf.param.set_value("system.storageStats", '1'))
 
     def printText(self, text):
         # Make sure we get printouts from the Crazyflie into the log (such as
@@ -112,6 +115,7 @@ class ConsoleTab(TabToolbox, console_tab_class):
         self._dumpSystemLoadButton.setEnabled(True)
         self._propellerTestButton.setEnabled(True)
         self._batteryTestButton.setEnabled(True)
+        self._storageStatsButton.setEnabled(True)
 
     def _disconnected(self, link_uri):
         """Callback for when the Crazyflie has been disconnected"""
@@ -119,6 +123,7 @@ class ConsoleTab(TabToolbox, console_tab_class):
         self._dumpAssertInformation.setEnabled(False)
         self._propellerTestButton.setEnabled(False)
         self._batteryTestButton.setEnabled(False)
+        self._storageStatsButton.setEnabled(False)
 
     def _link_established(self, link_uri):
         """Callback when the first packet on a new link is received"""

--- a/src/cfclient/ui/tabs/consoleTab.ui
+++ b/src/cfclient/ui/tabs/consoleTab.ui
@@ -78,6 +78,16 @@
         </widget>
        </item>
        <item>
+        <widget class="QPushButton" name="_storageStatsButton">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Storage Stats</string>
+         </property>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>


### PR DESCRIPTION
This PR adds support for printing the storage statistics implemented in bitcraze/crazyflie-firmware#1130.