### PR TITLE
Fixed regex bug in file dialog

### DIFF
--- a/src/cfclient/ui/dialogs/anchor_position_dialog.py
+++ b/src/cfclient/ui/dialogs/anchor_position_dialog.py
@@ -28,6 +28,7 @@ Dialog box used to configure anchor positions. Used from the LPS tab.
 import logging
 
 import cfclient
+from cfclient.utils.logconfigreader import FILE_REGEX_YAML
 from PyQt5 import QtWidgets
 from PyQt5 import uic
 from PyQt5.QtCore import QAbstractTableModel, QVariant, Qt
@@ -212,7 +213,7 @@ class AnchorPositionDialog(QtWidgets.QWidget, anchor_postiong_widget_class):
         self._data_model.anchor_postions_updated(anchor_positions)
 
     def _load_button_clicked(self):
-        names = QFileDialog.getOpenFileName(self, 'Open file', self._helper.current_folder, "*.yaml;*.*")
+        names = QFileDialog.getOpenFileName(self, 'Open file', self._helper.current_folder, FILE_REGEX_YAML)
 
         if names[0] == '':
             return
@@ -234,7 +235,7 @@ class AnchorPositionDialog(QtWidgets.QWidget, anchor_postiong_widget_class):
         for id, pos in anchor_positions.items():
             data[id] = {'x': pos[0], 'y': pos[1], 'z': pos[2]}
 
-        names = QFileDialog.getSaveFileName(self, 'Save file', self._helper.current_folder, "*.yaml;*.*")
+        names = QFileDialog.getSaveFileName(self, 'Save file', self._helper.current_folder, FILE_REGEX_YAML)
 
         if names[0] == '':
             return

--- a/src/cfclient/ui/tabs/lighthouse_tab.py
+++ b/src/cfclient/ui/tabs/lighthouse_tab.py
@@ -49,6 +49,7 @@ from cflib.localization import LighthouseConfigFileManager
 from cfclient.ui.dialogs.lighthouse_bs_geometry_dialog import LighthouseBsGeometryDialog
 from cfclient.ui.dialogs.basestation_mode_dialog import LighthouseBsModeDialog
 from cfclient.ui.dialogs.lighthouse_system_type_dialog import LighthouseSystemTypeDialog
+from cfclient.utils.logconfigreader import FILE_REGEX_YAML
 
 from vispy import scene
 import numpy as np
@@ -676,7 +677,7 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
                         label.setToolTip('')
 
     def _load_sys_config_button_clicked(self):
-        names = QFileDialog.getOpenFileName(self, 'Open file', self._helper.current_folder, "*.yaml;;*.*")
+        names = QFileDialog.getOpenFileName(self, 'Open file', self._helper.current_folder, FILE_REGEX_YAML)
 
         if names[0] == '':
             return
@@ -698,7 +699,7 @@ class LighthouseTab(TabToolbox, lighthouse_tab_class):
         self._save_sys_config(self._lh_geos, calibs, system_type)
 
     def _save_sys_config(self, geos, calibs, system_type):
-        names = QFileDialog.getSaveFileName(self, 'Save file', self._helper.current_folder, "*.yaml;;*.*")
+        names = QFileDialog.getSaveFileName(self, 'Save file', self._helper.current_folder, FILE_REGEX_YAML)
 
         if names[0] == '':
             return

--- a/src/cfclient/utils/logconfigreader.py
+++ b/src/cfclient/utils/logconfigreader.py
@@ -55,6 +55,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_CONF_NAME = 'log_config'
 DEFAULT_CATEGORY_NAME = 'category'
 
+FILE_REGEX_YAML = "Config *.yaml;;All *.*"
+
 
 class LogConfigReader():
     """Reads logging configurations from file"""

--- a/src/cfloader/__init__.py
+++ b/src/cfloader/__init__.py
@@ -35,8 +35,6 @@ import cflib.crtp
 from cflib.bootloader import Bootloader, Target
 from cflib.bootloader.boottypes import BootVersion
 
-from typing import Optional, List
-
 
 def main():
     # Initialise the CRTP link driver


### PR DESCRIPTION
There was a bug when trying to open the config file in the loco tab where the `.yaml` file couldn't be seen. This was caused by a small regex bug in the code. This PR fixes the bug and replaces the regex by a variable since the regex is used at multiple places, so we now only have to change it on one place if needed in the future.