### PR TITLE
Use bcLoco to identify Loco deck

### DIFF
--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -360,7 +360,7 @@ class FlightTab(TabToolbox, flight_tab_class):
             return
 
         #                  flowV1    flowV2     LightHouse       LPS
-        position_decks = ['bcFlow', 'bcFlow2', 'bcLighthouse4', 'bcDWM1000']
+        position_decks = ['bcFlow', 'bcFlow2', 'bcLighthouse4', 'bcLoco', 'bcDWM1000']
         for deck in position_decks:
             if int(self._helper.cf.param.values['deck'][deck]) == 1:
                 self.commanderBox.setEnabled(True)

--- a/src/cfclient/ui/tabs/locopositioning_tab.py
+++ b/src/cfclient/ui/tabs/locopositioning_tab.py
@@ -532,8 +532,9 @@ class LocoPositioningTab(TabToolbox, locopositioning_tab_class):
         def register(group, param):
             if self._is_in_param_toc(group, param):
                 logger.info("Requesting loco deck parameter")
-                self._helper.cf.param.add_update_callback(group=group, name=param,
-                    cb=self._cb_param_to_detect_loco_deck_signal.emit)
+                self._helper.cf.param.add_update_callback(group=group,
+                                                          name=param,
+                                                          cb=self._cb_param_to_detect_loco_deck_signal.emit)
 
         register(group, 'bcLoco')
         register(group, 'bcDWM1000')  # For backwards compatibility

--- a/src/cfclient/ui/tabs/locopositioning_tab.py
+++ b/src/cfclient/ui/tabs/locopositioning_tab.py
@@ -528,13 +528,15 @@ class LocoPositioningTab(TabToolbox, locopositioning_tab_class):
     def _request_param_to_detect_loco_deck(self):
         """Send a parameter request to detect if the Loco deck is installed"""
         group = 'deck'
-        param = 'bcDWM1000'
 
-        if self._is_in_param_toc(group, param):
-            logger.info("Requesting loco deck parameter")
-            self._helper.cf.param.add_update_callback(
-                group=group, name=param,
-                cb=self._cb_param_to_detect_loco_deck_signal.emit)
+        def register(group, param):
+            if self._is_in_param_toc(group, param):
+                logger.info("Requesting loco deck parameter")
+                self._helper.cf.param.add_update_callback(group=group, name=param,
+                    cb=self._cb_param_to_detect_loco_deck_signal.emit)
+
+        register(group, 'bcLoco')
+        register(group, 'bcDWM1000')  # For backwards compatibility
 
     def _cb_param_to_detect_loco_deck(self, name, value):
         """Callback from the parameter sub system when the Loco deck detection


### PR DESCRIPTION
This PR updates the Loco deck id according to bitcraze/crazyflie-firmware#1196