### PR TITLE
Update commander in flight tab

### DIFF
--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -30,7 +30,6 @@ The flight control tab shows telemetry data and flight settings.
 """
 
 import logging
-import time
 from enum import Enum
 
 from PyQt5 import uic
@@ -42,7 +41,6 @@ from cfclient.ui.widgets.ai import AttitudeIndicator
 
 from cfclient.utils.config import Config
 from cflib.crazyflie.log import LogConfig
-from cflib.positioning.position_hl_commander import PositionHlCommander
 
 from cfclient.utils.input import JoystickReader
 


### PR DESCRIPTION
The commander buttons in the flight tab are implemented in a way that freezes the GUI when used. There are also issues in absolute positioning systems as the commander goes to a position close to the origin (which is bad if the take-off position is far away).

This PR calls the high level commander directly instead of using the wrapper class from the library.

Closes #605