### PR TITLE
Accept flashing of .zip files without target

### DIFF
--- a/docs/functional-areas/cfloader.md
+++ b/docs/functional-areas/cfloader.md
@@ -99,7 +99,7 @@ Flashing new firmware for the STM32 MCU with warmbooting with a known uri:
     Flashing 1 of 1 to stm32 (fw): 76435 bytes (75 pages) ..........10..........10..........10..........10..........10..........10..........10.....5
     Reset in firmware mode ..
 
-Flash a new firmware package (containing both nRF51 and STM32 firmware):
+Flash a new firmware package (containing both nRF51, STM32 and deck firmwares):
 
     crazyflie-clients-python$ bin/cfloader flash cf2_dev_update.zip
     Restart the Crazyflie you want to bootload in the next  10 seconds ...  done!
@@ -121,20 +121,31 @@ The AI-deck should be mounted on the Crazyflie when running the cfloader.
 
 Flash a new firmware to the ESP on the AI-deck:
 
-    crazyflie-clients-python$ bin/cfloader flash myApp.bin deck-bcAI:esp-fw -w radio://0/30/2M
+    crazyflie-clients-python$ bin/cfloader flash myEspApp.bin deck-bcAI:esp-fw -w radio://0/30/2M
     Reset to bootloader mode ...
     | 4% Writing to bcAI:esp deck memory
     / 9% Writing to bcAI:esp deck memory
     - 14% Writing to bcAI:esp deck memory
     \ 19% Writing to bcAI:esp deck memory
+    ...
 
 Flash a new firmware to the GAP8 on the AI-deck:
 
-    crazyflie-clients-python$ bin/cfloader flash myApp.bin deck-bcAI:gap8-fw -w radio://0/30/2M
+    crazyflie-clients-python$ bin/cfloader flash myGap8App.bin deck-bcAI:gap8-fw -w radio://0/30/2M
     Reset to bootloader mode ...
     Skipping bcAI:esp
     | 4% Writing to bcAI:gap8 deck memory
     / 9% Writing to bcAI:gap8 deck memory
     - 14% Writing to bcAI:gap8 deck memory
     \ 19% Writing to bcAI:gap8 deck memory
+    ...
+
+Flash a new firmware to the ESP on the AI-deck from a release zip.
+
+    crazyflie-clients-python$ bin/cfloader flash a-release.zip deck-bcAI:esp-fw -w radio://0/30/2M
+    Reset to bootloader mode ...
+    Deck bcAI:esp, reset to bootloader
+    | 0% Writing to bcAI:esp deck memory
+    / 1% Writing to bcAI:esp deck memory
+    - 2% Writing to bcAI:esp deck memory
     ...

--- a/src/cfloader/__init__.py
+++ b/src/cfloader/__init__.py
@@ -150,7 +150,11 @@ def main():
             # flash_full called with no filename will not flash, just call
             # our info callback
             bl.flash_full(None, None, warm_boot, None, print_info)
-        elif action == "flash" and filename and targets:
+        elif action == "flash" and filename:
+            is_target_required = not filename.endswith('.zip')
+            if (is_target_required and not targets):
+                print("The flash action with a non .zip file requires a target")
+                sys.exit(-1)
             try:
                 bl.flash_full(None, filename, warm_boot, targets)
             except Exception as e:


### PR DESCRIPTION
This PR fixes a bug in the cfloader (from command line) that makes it imposiible to flash .zip files. There is currently a requirement that a target is supplied, also if everything in the zip should be flashed. 
The changes in the PR makes cfloader behave as stated in the documentation.