### PR TITLE
Add support for upgrading nRF51 soft device and bootloader

### DIFF
--- a/src/cfloader/__init__.py
+++ b/src/cfloader/__init__.py
@@ -111,10 +111,10 @@ def main():
         for t in sys.argv[2:]:
             if t.startswith("deck-"):
                 [deck, target, type] = t.split("-")
-                targets.append(Target("deck", target, type))
+                targets.append(Target("deck", target, type, [], []))
             else:
                 [target, type] = t.split("-")
-                targets.append(Target("cf2", target, type))
+                targets.append(Target("cf2", target, type, [], []))
     else:
         print("Action", sys.argv[0], "unknown!")
         sys.exit(-1)


### PR DESCRIPTION
Part of the API for the library changed when implementing the nRF51 bootloader update. This PR uses the new API. More information here https://github.com/bitcraze/crazyflie-lib-python/pull/439