### PR TITLE
Gray out unclickable buttons in default theme

### DIFF
--- a/src/cfclient/utils/ui.py
+++ b/src/cfclient/utils/ui.py
@@ -68,6 +68,10 @@ class UiUtils:
                 border-radius: 2px;
                 background-color: """ + COLOR_BLUE + """;
             }
+
+            QAbstractButton:disabled {
+                color: gray;
+            }
     """
 
     _THEME_HACKER = """


### PR DESCRIPTION
Gray out unclickable buttons in all tabs when using the default theme.

![Screenshot from 2024-02-28 16-32-05](https://github.com/bitcraze/crazyflie-clients-python/assets/49898887/2d2b2ab7-b070-4f54-8d36-760130094633)
*Before; arm button, expansion board drop down menu, command based flight control appear clickable even though no Crazyflie is connected* 
![Screenshot from 2024-02-28 16-32-47](https://github.com/bitcraze/crazyflie-clients-python/assets/49898887/915339b2-4b9b-400e-85e2-c6ab14449c48)
*After; disabled buttons are grayed out* 