### PR TITLE
Addition of persistent parameter saving, loading to file and clearing

### DIFF
--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -320,7 +320,7 @@ class ParamTab(TabToolbox, param_tab_class):
         self.paramTree.selectionModel().selectionChanged.connect(self._paramChanged)
 
         self._load_param_button.clicked.connect(self._load_param_button_clicked)
-        self._save_param_button.clicked.connect(self._save_param_button_clicked)
+        self._dump_param_button.clicked.connect(self._dump_param_button_clicked)
         self._clear_param_button.clicked.connect(self._clear_stored_persistent_params_button_clicked)
 
         self._is_connected = False
@@ -421,7 +421,7 @@ class ParamTab(TabToolbox, param_tab_class):
     def _update_param_io_buttons(self):
         enabled = self._is_connected
         self._load_param_button.setEnabled(enabled)
-        self._save_param_button.setEnabled(enabled)
+        self._dump_param_button.setEnabled(enabled)
         self._clear_param_button.setEnabled(enabled)
 
     def _load_param_button_clicked(self):

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -454,7 +454,9 @@ class ParamTab(TabToolbox, param_tab_class):
         self._update_param_io_buttons()
         dlg = QMessageBox(self)
         dlg.setWindowTitle("Info")
-        dlg.setText('Loaded persistent parameters from file:\n' + "\n".join([f"{_param_name}: {parameters[_param_name].stored_value}" for _param_name in _set_param_names]))
+        _parameters_and_values = [f"{_param_name}:{parameters[_param_name].stored_value}"
+                                  for _param_name in _set_param_names]
+        dlg.setText('Loaded persistent parameters from file:\n' + "\n".join(_parameters_and_values))
         dlg.setIcon(QMessageBox.Icon.NoIcon)
         dlg.exec()
 
@@ -512,7 +514,9 @@ class ParamTab(TabToolbox, param_tab_class):
         ParamFileManager.write(filename, stored_persistent_params)
         dlg = QMessageBox(self)
         dlg.setWindowTitle('Info')
-        dlg.setText('Dumped persistent parameters to file:\n' + "\n".join([f"{_param_name}: {stored_persistent_params[_param_name].stored_value}" for _param_name in stored_persistent_params.keys()]))
+        _parameters_and_values = [f"{_param_name}: {stored_persistent_params[_param_name].stored_value}"
+                                  for _param_name in stored_persistent_params.keys()]
+        dlg.setText('Dumped persistent parameters to file:\n' + "\n".join(_parameters_and_values))
         dlg.setIcon(QMessageBox.Icon.NoIcon)
         dlg.exec()
 

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -436,15 +436,22 @@ class ParamTab(TabToolbox, param_tab_class):
             if not success:
                 QMessageBox.about(self, 'Warning', f'Failed to persistently store {complete_name}!')
 
+        _set_param_names = []
         for param, state in parameters.items():
             if state.is_stored:
                 try:
                     self.cf.param.set_value(param, state.stored_value)
+                    _set_param_names.append(param)
                 except Exception:
                     QMessageBox.about(self, 'Warning', f'Failed to set {param}!')
                 self.cf.param.persistent_store(param, _is_persistent_stored_callback)
 
         self._update_param_io_buttons()
+        dlg = QMessageBox(self)
+        dlg.setWindowTitle("Info")
+        dlg.setText('Loaded persistent parameters from file:\n' + "\n".join([f"{_param_name}: {parameters[_param_name].stored_value}" for _param_name in _set_param_names]))
+        dlg.setIcon(QMessageBox.Icon.NoIcon)
+        dlg.exec()
 
     def _get_persistent_state(self, complete_param_name):
         wait_for_callback_event = Event()
@@ -498,6 +505,11 @@ class ParamTab(TabToolbox, param_tab_class):
             filename = names[0]
 
         ParamFileManager.write(filename, stored_persistent_params)
+        dlg = QMessageBox(self)
+        dlg.setWindowTitle('Info')
+        dlg.setText('Dumped persistent parameters to file:\n' + "\n".join([f"{_param_name}: {stored_persistent_params[_param_name].stored_value}" for _param_name in stored_persistent_params.keys()]))
+        dlg.setIcon(QMessageBox.Icon.NoIcon)
+        dlg.exec()
 
     def _clear_persistent_parameter(self, complete_param_name):
         wait_for_callback_event = Event()

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -434,7 +434,10 @@ class ParamTab(TabToolbox, param_tab_class):
 
         def _is_persistent_stored_callback(complete_name, success):
             if not success:
+                print(f'Persistent params: failed to store {complete_name}!')
                 QMessageBox.about(self, 'Warning', f'Failed to persistently store {complete_name}!')
+            else:
+                print(f'Persistent params: stored {complete_name}!')
 
         _set_param_names = []
         for param, state in parameters.items():
@@ -443,7 +446,9 @@ class ParamTab(TabToolbox, param_tab_class):
                     self.cf.param.set_value(param, state.stored_value)
                     _set_param_names.append(param)
                 except Exception:
+                    print(f'Failed to set {param}!')
                     QMessageBox.about(self, 'Warning', f'Failed to set {param}!')
+                print(f'Set {param}!')
                 self.cf.param.persistent_store(param, _is_persistent_stored_callback)
 
         self._update_param_io_buttons()
@@ -516,9 +521,9 @@ class ParamTab(TabToolbox, param_tab_class):
 
         def is_stored_cleared(complete_name, success):
             if success:
-                print(f'Cleared {complete_name}!')
+                print(f'Persistent params: cleared {complete_name}!')
             else:
-                print(f'Failed to clear {complete_name}!')
+                print(f'Persistent params: failed to clear {complete_name}!')
             wait_for_callback_event.set()
 
         self.cf.param.persistent_clear(complete_param_name, callback=is_stored_cleared)

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -513,9 +513,16 @@ class ParamTab(TabToolbox, param_tab_class):
         wait_for_callback_event.wait()
 
     def _clear_stored_persistent_params_button_clicked(self):
-        stored_persistent_params = self._get_all_stored_persistent_param_names()
-        for complete_name in stored_persistent_params:
-            self._clear_persistent_parameter(complete_name)
+        dlg = QMessageBox(self)
+        dlg.setWindowTitle("Clear Stored Parameters Confirmation")
+        dlg.setText("Are you sure you want to clear your stored persistent parameter?")
+        dlg.setStandardButtons(QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No)
+        button = dlg.exec()
+
+        if button == QMessageBox.StandardButton.Yes:
+            stored_persistent_params = self._get_all_stored_persistent_param_names()
+            for complete_name in stored_persistent_params:
+                self._clear_persistent_parameter(complete_name)
 
     def _connected(self, link_uri):
         self._model.reset()

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -487,18 +487,17 @@ class ParamTab(TabToolbox, param_tab_class):
                 stored_params[complete_name] = state
         return stored_params
 
-    def _save_param_button_clicked(self):
-        if self._model._enabled:
-            stored_persistent_params = self._get_all_stored_persistent_params()
-            names = QFileDialog.getSaveFileName(self, 'Save file', cfclient.config_path, FILE_REGEX_YAML)
-            if names[0] == '':
-                return
-            if not names[0].endswith(".yaml"):
-                filename = names[0] + ".yaml"
-            else:
-                filename = names[0]
+    def _dump_param_button_clicked(self):
+        stored_persistent_params = self._get_all_stored_persistent_params()
+        names = QFileDialog.getSaveFileName(self, 'Save file', cfclient.config_path, FILE_REGEX_YAML)
+        if names[0] == '':
+            return
+        if not names[0].endswith(".yaml"):
+            filename = names[0] + ".yaml"
+        else:
+            filename = names[0]
 
-            ParamFileManager.write(filename, stored_persistent_params)
+        ParamFileManager.write(filename, stored_persistent_params)
 
     def _clear_persistent_parameter(self, complete_param_name):
         wait_for_callback_event = Event()

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -321,7 +321,7 @@ class ParamTab(TabToolbox, param_tab_class):
 
         self._load_param_button.clicked.connect(self._load_param_button_clicked)
         self._save_param_button.clicked.connect(self._save_param_button_clicked)
-        self._reset_param_button.clicked.connect(self._reset_param_button_clicked)
+        self._clear_param_button.clicked.connect(self._clear_stored_persistent_params_button_clicked)
 
         self._is_connected = False
         self._update_param_io_buttons()
@@ -422,7 +422,7 @@ class ParamTab(TabToolbox, param_tab_class):
         enabled = self._is_connected
         self._load_param_button.setEnabled(enabled)
         self._save_param_button.setEnabled(enabled)
-        self._reset_param_button.setEnabled(enabled)
+        self._clear_param_button.setEnabled(enabled)
 
     def _load_param_button_clicked(self):
         names = QFileDialog.getOpenFileName(self, 'Open file', cfclient.config_path, FILE_REGEX_YAML)
@@ -440,7 +440,7 @@ class ParamTab(TabToolbox, param_tab_class):
             if state.is_stored:
                 try:
                     self.cf.param.set_value(param, state.stored_value)
-                except Exception as e:
+                except Exception:
                     QMessageBox.about(self, 'Warning', f'Failed to set {param}!')
                 self.cf.param.persistent_store(param, _is_persistent_stored_callback)
 
@@ -513,7 +513,7 @@ class ParamTab(TabToolbox, param_tab_class):
         self.cf.param.persistent_clear(complete_param_name, callback=is_stored_cleared)
         wait_for_callback_event.wait()
 
-    def _reset_param_button_clicked(self):
+    def _clear_stored_persistent_params_button_clicked(self):
         stored_persistent_params = self._get_all_stored_persistent_param_names()
         for complete_name in stored_persistent_params:
             self._clear_persistent_parameter(complete_name)

--- a/src/cfclient/ui/tabs/paramTab.ui
+++ b/src/cfclient/ui/tabs/paramTab.ui
@@ -23,7 +23,25 @@
     <item row="1" column="0">
         <widget class="QTreeView" name="paramTree"/>
    </item>
-   <item row="0" column="1" rowspan="2">
+    <item row="0" column="1">
+        <layout class="QGridLayout" name="paramLoaderLayout">
+            <item row="0" column="0">
+                <widget class="QPushButton" name="_save_param_button">
+                    <property name="text">
+                        <string>Save params</string>
+                    </property>
+                </widget>
+            </item>
+            <item row="0" column="1">
+                <widget class="QPushButton" name="_load_param_button">
+                    <property name="text">
+                        <string>Load params</string>
+                    </property>
+                </widget>
+            </item>
+        </layout>
+    </item>
+   <item row="1" column="1" rowspan="2">
     <widget class="QFrame" name="paramDetails">
         <property name="frameShape">
             <enum>QFrame::Box</enum>

--- a/src/cfclient/ui/tabs/paramTab.ui
+++ b/src/cfclient/ui/tabs/paramTab.ui
@@ -22,24 +22,6 @@
     </item>
     <item row="1" column="0">
         <widget class="QTreeView" name="paramTree"/>
-   </item>
-    <item row="0" column="1">
-        <layout class="QGridLayout" name="paramLoaderLayout">
-            <item row="0" column="0">
-                <widget class="QPushButton" name="_save_param_button">
-                    <property name="text">
-                        <string>Save params</string>
-                    </property>
-                </widget>
-            </item>
-            <item row="0" column="1">
-                <widget class="QPushButton" name="_load_param_button">
-                    <property name="text">
-                        <string>Load params</string>
-                    </property>
-                </widget>
-            </item>
-        </layout>
     </item>
    <item row="1" column="1" rowspan="2">
     <widget class="QFrame" name="paramDetails">
@@ -199,6 +181,42 @@
             </item>
         </layout>
     </widget>
+   </item>
+   <item row="0" column="1">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Persistent Parameter IO</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QPushButton" name="_save_param_button">
+         <property name="text">
+          <string>Save</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="_load_param_button">
+         <property name="text">
+          <string>Load</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="_reset_param_button">
+         <property name="text">
+          <string>Reset</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/src/cfclient/ui/tabs/paramTab.ui
+++ b/src/cfclient/ui/tabs/paramTab.ui
@@ -208,9 +208,9 @@
         </widget>
        </item>
        <item>
-        <widget class="QPushButton" name="_reset_param_button">
+        <widget class="QPushButton" name="_clear_param_button">
          <property name="text">
-          <string>Reset</string>
+          <string>Clear</string>
          </property>
         </widget>
        </item>

--- a/src/cfclient/ui/tabs/paramTab.ui
+++ b/src/cfclient/ui/tabs/paramTab.ui
@@ -187,16 +187,16 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Persistent Parameter IO</string>
+        <string>Persistent Parameter Management</string>
        </property>
       </widget>
      </item>
      <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QPushButton" name="_save_param_button">
+        <widget class="QPushButton" name="_dump_param_button">
          <property name="text">
-          <string>Save</string>
+          <string>Dump</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Note that this pull request depends on https://github.com/bitcraze/crazyflie-lib-python/pull/443

This pull request primarily focuses on the addition of parameter file loading and saving capabilities. These new features allow users to store and retrieve persistent parameter configurations to/from file, improving usability and efficiency. Furthermore, it adds a clear 

Key changes include:

1. **Parameter File Loading**: The `_load_param_button_clicked` method has been added, which allows users to load persistent parameters from a YAML file. The method reads the file using `ParamFileManager.read` and sets the parameter values accordingly.

2. **Parameter File Saving**: The `_dump_param_button_clicked` method has been added, which allows users to save the current parameters to a YAML file. The method retrieves the current parameters and their values and writes them to the file using `ParamFileManager.write`.

3. **Persistent Parameter Clearing**: The `_clear_persistent_parameter` method has been added, which allows users to clear a specific persistent parameter. The method sends a clear request for the given parameter to the Crazyflie using `self.cf.param.persistent_clear`. It uses a callback function `is_stored_cleared` to handle the result of the clearing operation and an `Event` object `wait_for_callback_event` to wait for the operation to complete. If the operation is successful, a message indicating the cleared parameter is printed. If the operation fails, a failure message is printed.

4. **Parameter IO GUI**: The parameter tab has been updated to include buttons for loading and saving parameter files, and for clearing the stored persistent parameters. These buttons are enabled or disabled based on the connection state.

5. **Error Handling**: If setting a parameter value or storing a parameter persistently from a loaded file fails, a warning message is displayed to the user.