### PR TITLE
fix raspberrypi bookworm

### DIFF
--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -16,7 +16,7 @@ On Raspberry bookwork it is required to create a *python venv* to install the cl
 
 Install dependencies:
 ```
-sudo apt install python3-pyqt6 pyqt6-dev-tools
+sudo apt install -y pipx python3-pyqt6 pyqt6-dev-tools
 ```
 
 Then, to install the client:
@@ -26,6 +26,7 @@ pipx install --system-site-packages .
 
 The ```--system-site-packages``` is the most important there since it allows to use pyqt we installed just above.
 The same flag can be passes to ```python3 -m venv``` in order to create a python venv that can run the client.
+The first time ```pipx``` will complain about binaries not being in the path. Rebooting the pie solves the problem and then the client can be launched by typing ```cfclient``` in a console.
 
 Permission for USB needs to be set as described bellow for Debian/Ubuntu
 

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -10,9 +10,27 @@ This project requires Python 3.8 - 3.12.
 There are a few things to sort out on your machine before you can install the client. Please see the appropriate
 section depending on your environment.
 
-### Debian/Ubuntu
+### Raspberrypy Bookworm+
 
-For <  Ubuntu 20.04 you will need to check first if which version your python is on and if you have 'python3' on your system.
+On Raspberry bookwork it is required to create a *python venv* to install the client but the system's pyqt6 should still be used.
+
+Install dependencies:
+```
+sudo apt install python3-pyqt6 pyqt6-dev-tools
+```
+
+Then, to install the client:
+```
+pipx install --system-site-packages .
+```
+
+The ```--system-site-packages``` is the most important there since it allows to use pyqt we installed just above.
+The same flag can be passes to ```python3 -m venv``` in order to create a python venv that can run the client.
+
+Permission for USB needs to be set as described bellow for Debian/Ubuntu
+
+
+### Debian/Ubuntu
 
 From a fresh Ubuntu 20.04 system and up, running the client form source requires git, pip and a lib for the Qt GUI.
 

--- a/setup.py
+++ b/setup.py
@@ -99,8 +99,8 @@ setup(
                       'numpy~=1.20',
                       'vispy~=0.13',
                       'pyserial~=3.5',
-                      'pyqt6~=6.5',
-                      'PyQt6-sip~=13.5',
+                      'pyqt6>=6.4',
+                      'PyQt6-sip>=13.4',
 
                       'pysdl2~=0.9.14 ; platform_system=="Windows" or platform_system=="Darwin"',
                       'pysdl2-dll==2.24.0 ; platform_system=="Windows" or platform_system=="Darwin"'],


### PR DESCRIPTION
This PR changes dependencies version and update documentation to fix the client on the latest version of Raspberrypi OS, Bookworm.

The change of pyqt6 dependency version will not affect new install on other systems.
