### PR TITLE
Fix client on mac sonoma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,8 @@ setup(
                       'pyqtgraph~=0.13',
                       'PyYAML~=6.0.1',
                       'numpy~=1.20',
-                      'vispy~=0.13',
+                      'vispy~=0.14.2',
+                      'pyopengl~=3.1.7',   # Requires for Vispy to work on MacOS Sonoma
                       'pyserial~=3.5',
                       'pyqt6>=6.4',
                       'PyQt6-sip>=13.4',


### PR DESCRIPTION
Add Pyopengl dependency to fix Vispy on MacOS Sonoma

This change should be harmless to other platform but it should be tested on
 - [x] Windows
 - [x] Linux x86
 - [x] Linux Raspberrypi
 - [x] Mac os 11 on x86