### PR TITLE
FlightTab: Assisted flight fix

### DIFF
--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -715,7 +715,7 @@ class FlightTab(TabToolbox, flight_tab_class):
             self.targetHeight.setEnabled(enabled)
             print('Chaning enable for target height: %s' % enabled)
         else:
-            self._helper.cf.param.set_value("flightmode.althold", str(enabled))
+            self._helper.cf.param.set_value("flightmode.althold", int(enabled))
 
     def alt1_updated(self, state):
         if state:


### PR DESCRIPTION
Booleans should be encoded as ints and not strings. Why this worked with pyqt5 is still obscured for me but it looks like its been a change. Regardless bools in other parts of this code is encoded as integers, so keeping it unified is a good idea