### PR TITLE
Implement x axis manipulation in plotting tab

### DIFF
--- a/src/cfclient/ui/widgets/plotter.ui
+++ b/src/cfclient/ui/widgets/plotter.ui
@@ -31,20 +31,51 @@
           <layout class="QGridLayout" name="gridLayout">
            <item row="1" column="0">
             <layout class="QGridLayout" name="gridLayout_5">
-             <item row="0" column="1">
-              <widget class="QLineEdit" name="_range_x_min">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
+             <item row="0" column="0">
+              <widget class="QRadioButton" name="_enable_range_x">
                <property name="text">
-                <string>0</string>
+                <string>Range (s)</string>
+               </property>
+               <property name="autoExclusive">
+                <bool>false</bool>
                </property>
               </widget>
              </item>
-             <item row="0" column="2">
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>-</string>
+             <item row="0" column="1">
+              <widget class="QDoubleSpinBox" name="_range_x_min">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="minimum">
+                <double>0</double>
+               </property>
+               <property name="maximum">
+                <double>86400</double>
+               </property>
+               <property name="singleStep">
+                <double>1</double>
+               </property>
+               <property name="value">
+                <double>0</double>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="4">
+              <widget class="QDoubleSpinBox" name="_range_x_max">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="minimum">
+                <double>0</double>
+               </property>
+               <property name="maximum">
+                <double>86400</double>
+               </property>
+               <property name="singleStep">
+                <double>1</double>
+               </property>
+               <property name="value">
+                <double>60</double>
                </property>
               </widget>
              </item>
@@ -70,7 +101,7 @@
                 <string/>
                </property>
                <property name="maximum">
-                <number>2000</number>
+                <number>3000</number>
                </property>
                <property name="singleStep">
                 <number>100</number>
@@ -80,47 +111,8 @@
                </property>
               </widget>
              </item>
-             <item row="0" column="3">
-              <widget class="QLineEdit" name="_range_x_max">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>1000</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QRadioButton" name="_enable_range_x">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>Range</string>
-               </property>
-               <property name="autoExclusive">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QRadioButton" name="_enable_manual_x">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="text">
-                <string>Manual</string>
-               </property>
-               <property name="autoExclusive">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
              <item row="2" column="0">
               <widget class="QRadioButton" name="_enable_seconds_x">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
                <property name="text">
                 <string>Seconds</string>
                </property>


### PR DESCRIPTION
The last N seconds can now be plotted.
A range can now be set in seconds (low, high limits). The starting range is automatically adapted to match the latest view in samples / seconds mode. This makes the range mode useful for zooming in on certain parts of the plot.

Changed x axis behavior such that the range configuration (samples, seconds, range) dictates x limits of the plot even if there is a (partial) lack of data for the range. Rather than stretching the plot as it fills up, now the entire plot limits are shown immediately. This immediate feedback helps with choosing a desirable x axis setting.