### PR TITLE
Fix bug by making decimal input handling locale-independent

### DIFF
--- a/src/cfclient/ui/widgets/plotwidget.py
+++ b/src/cfclient/ui/widgets/plotwidget.py
@@ -159,7 +159,8 @@ class PlotWidget(QtWidgets.QWidget, plot_widget_class):
         self._first_ts = None
 
         self._x_range = (
-            float(self._range_x_min.text()), float(self._range_x_max.text()))
+            float(self._range_x_min.text().replace(',', '.')), float(self._range_x_max.text().replace(',', '.'))
+        )
         self._nbr_samples = int(self._nbr_of_samples_x.text())
         self._nbr_of_samples_x.valueChanged.connect(self._nbr_samples_changed)
         self._nbr_seconds = int(self._nbr_of_seconds_x.text())


### PR DESCRIPTION
This PR addresses a critical bug where decimal inputs in the plotter's X range values were not processed correctly in locales that use a comma as the decimal separator. By replacing commas with dots, we ensure that numeric inputs are handled consistently across all locales, making the application's numeric input processing locale-independent.

This update sidesteps the complexities associated with using the `locale` module, providing a straightforward but dirty solution to the issue.