### PR TITLE
ZMQ Example: ensure the ramp.c script sends zero thrust after script finishes

### DIFF
--- a/examples/zmq_clients/ramp_c/ramp.c
+++ b/examples/zmq_clients/ramp_c/ramp.c
@@ -36,9 +36,11 @@ int main()
     sleep(1);
   }
 
-  sprintf(message, messageFmt, 0);
+  sprintf(message, messageFmt, 0.0f);
   zmq_send(socket_zmq, message, strlen(message), 0);
   printf("\rThrust = %f%%\n", 0.0);
+  fflush(stdout);
+  sleep(1);
 
   zmq_close(socket_zmq);
   zmq_ctx_destroy(context);


### PR DESCRIPTION
## Problem Statement

The `ramp.c` script was not sending zero thrust as intended after ramping up from 0 to 30% thrust value. As a result, when I ran the example script with my crazyflie bolt 1.1, the motors were left running at 30% thrust after the script had exited.

## Solution

Ensure that the `sprintf` has a float as input (instead of an integer) and then add the `fflush` and `sleep` statements to ensure the message is properly sent to `zmq` before being closed. I verified this solution worked as intended on my crazyflie bolt 1.1