### PR TITLE
Replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/src/cfclient/__init__.py
+++ b/src/cfclient/__init__.py
@@ -38,10 +38,10 @@ else:
 config_path = AppDirs("cfclient", "Bitcraze").user_config_dir
 
 if not hasattr(sys, 'frozen'):
-    import pkg_resources
+    from importlib.metadata import version, PackageNotFoundError
     try:
-        VERSION = pkg_resources.require("cfclient")[0].version
-    except pkg_resources.DistributionNotFound:
+        VERSION = version("cfclient")
+    except PackageNotFoundError:
         VERSION = "dev"
 else:
     try:


### PR DESCRIPTION
- Update VERSION detection in cfclient/__init__.py to use importlib.metadata instead of the deprecated pkg_resources
- Maintain same functionality and fallback behavior for different scenarios