### PR TITLE
Catch concrete exceptions

### DIFF
--- a/src/cfclient/__init__.py
+++ b/src/cfclient/__init__.py
@@ -52,5 +52,5 @@ else:
 try:
     with open(os.path.join(module_path, "resources/log_param_doc.json")) as f:
         log_param_doc = json.load(f)
-except:  # noqa
+except (IOError, OSError, json.JSONDecodeError):
     log_param_doc = None

--- a/src/cfclient/ui/tabs/LogTab.py
+++ b/src/cfclient/ui/tabs/LogTab.py
@@ -99,7 +99,7 @@ class LogTab(TabToolbox, param_tab_class):
                         log_groups = cfclient.log_param_doc['logs'][group]
                         log_variable = log_groups['variables'][param]
                         item.setData(4, Qt.ItemDataRole.DisplayRole, log_variable['short_desc'])
-                    except:  # noqa
+                    except (KeyError, TypeError, AttributeError):
                         pass
 
                 groupItem.addChild(item)
@@ -112,5 +112,5 @@ class LogTab(TabToolbox, param_tab_class):
                     label = QtWidgets.QLabel(log_groups['desc'])
                     label.setWordWrap(True)
                     self.logTree.setItemWidget(groupItem, 4, label)
-                except:  # noqa
+                except (KeyError, TypeError, AttributeError):
                     pass

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -398,7 +398,7 @@ class ParamTab(TabToolbox, param_tab_class):
 
                     self.paramDetailsDescription.setWordWrap(True)
                     self.paramDetailsDescription.setText(desc.replace('\n', ''))
-                except:  # noqa
+                except (KeyError, TypeError, AttributeError):
                     self.paramDetailsDescription.setText('')
 
             complete = f'{group}.{param}'


### PR DESCRIPTION
Bare exceptions are considered a bad practice.
`#noqa` was put because linter complained on the lines for a reason.