### PR TITLE
Added error when `Set BS channel` is failed

### DIFF
--- a/src/cfclient/ui/dialogs/basestation_mode_dialog.py
+++ b/src/cfclient/ui/dialogs/basestation_mode_dialog.py
@@ -116,8 +116,13 @@ class LighthouseBsModeDialog(QtWidgets.QWidget, basestation_mode_widget_class):
         dev = self._device
         try:
             ser = serial.Serial(dev, timeout=0.4)
-        except serial.SerialException as e:
-            self._basestation_mode_status.setText('Permission denied: cannot access serial port.\n Try running: \"sudo usermod -aG dialout [username]\" and then restart your computer')
+        except serial.SerialException:
+            self._basestation_mode_status.setText(
+                'Permission denied: cannot access serial port.\n'
+                'Try running: \"sudo usermod -aG dialout [username]\" '
+                'and then restart your computer.'
+            )
+
             self._set_basestation_button.setEnabled(True)
             return
 


### PR DESCRIPTION
This should fix #760 
When the user doesn't have permission to write to serial ports, they will get a permission error in the **Basestation configuration** tab.
<img width="579" height="333" alt="Screenshot from 2025-10-22 15-36-44" src="https://github.com/user-attachments/assets/a181e296-fe49-4d13-82c5-38f76311eb57" />
