### PR TITLE
Fixed bug where program button did not enable for "from file" flashing in bootloader dialog

### DIFF
--- a/src/cfclient/ui/dialogs/bootloader.py
+++ b/src/cfclient/ui/dialogs/bootloader.py
@@ -313,7 +313,7 @@ class BootloaderDialog(QtWidgets.QWidget, service_dialog_class):
 
         self.firmwareDropdown.setSizeAdjustPolicy(QtWidgets.QComboBox.SizeAdjustPolicy.AdjustToContents)
         self._update_firmware_dropdown(True)
-    
+
     def _has_selected_file(self) -> bool:
         return bool(self.imagePathLine.text())
 


### PR DESCRIPTION
This PR fixes the bug where the program button in the bootloader dialog did not enable when trying to flash from the "from file" tab. If the user added a file the program button did not enable, but it was still possible to flash by selecting a platform in the first tab and then going back to the "from file" tab. Now, it becomes enabled based on what is selected in each tab (expected behavior). 