### PR TITLE
Migrated platform commands to supervisor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">= 3.10"
 
 dependencies = [
-        "cflib~=0.1.31",
+        "cflib @ git+https://github.com/bitcraze/crazyflie-lib-python.git@153248591ec26f2206d4c029a174f10c8aaaedda",
         "setuptools",
         "appdirs~=1.4.0",
         "pyzmq~=26.0",

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -577,7 +577,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         if (self.uiState == UIState.CONNECTED):
             # Send both emergency stop and disarm
             # TODO krri Disarm?
-            self.cf.loc.send_emergency_stop()
+            self.cf.supervisor.send_emergency_stop()
 
     def _update_battery(self, timestamp, data, logconf):
         self.batteryBar.setValue(int(data["pm.vbat"] * 1000))

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -618,12 +618,12 @@ class FlightTab(TabToolbox, flight_tab_class):
         if self._is_flying() and not from_controller:
             self._helper.cf.loc.send_emergency_stop()
         elif self._is_crashed():
-            self._helper.cf.platform.send_crash_recovery_request()
+            self._helper.cf.supervisor.send_crash_recovery_request()
         elif self._is_armed():
-            self._helper.cf.platform.send_arming_request(False)
+            self._helper.cf.supervisor.send_arming_request(False)
         elif self._can_arm():
             self.armButton.setStyleSheet("background-color: orange")
-            self._helper.cf.platform.send_arming_request(True)
+            self._helper.cf.supervisor.send_arming_request(True)
 
     def flightmodeChange(self, item):
         Config().set("flightmode", str(self.flightModeCombo.itemText(item)))

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -609,14 +609,14 @@ class FlightTab(TabToolbox, flight_tab_class):
     def updateEmergencyStop(self, emergencyStop):
         if emergencyStop:
             self.setMotorLabelsEnabled(False)
-            self._helper.cf.loc.send_emergency_stop()
+            self._helper.cf.supervisor.send_emergency_stop()
             # TODO krri disarm?
         else:
             self.setMotorLabelsEnabled(True)
 
     def updateArm(self, from_controller=False):
         if self._is_flying() and not from_controller:
-            self._helper.cf.loc.send_emergency_stop()
+            self._helper.cf.supervisor.send_emergency_stop()
         elif self._is_crashed():
             self._helper.cf.supervisor.send_crash_recovery_request()
         elif self._is_armed():


### PR DESCRIPTION
In this [cflib PR](https://github.com/bitcraze/crazyflie-lib-python/pull/581), some platform commands (`send_arming_request` and `send_recovery_request`) are moved from `platformservice.py` to `supervisor.py`.
This PR updates these commands in the cfclient's side. Should be merged after the [firmware PR](https://github.com/bitcraze/crazyflie-firmware/pull/1560) and the [cflib PR](https://github.com/bitcraze/crazyflie-lib-python/pull/581) are merged.