### PR TITLE
Add thrust interlock and move gamepad status to Flight tab

### DIFF
--- a/src/cfclient/ui/dialogs/inputconfigdialogue.py
+++ b/src/cfclient/ui/dialogs/inputconfigdialogue.py
@@ -35,6 +35,7 @@ from PyQt6.QtCore import QThread
 from PyQt6.QtCore import QTimer
 from PyQt6.QtCore import pyqtSignal
 from PyQt6.QtWidgets import QMessageBox
+from cfclient.utils.config import Config
 from cfclient.utils.config_manager import ConfigManager
 from PyQt6 import QtWidgets
 from PyQt6 import uic
@@ -50,6 +51,8 @@ logger = logging.getLogger(__name__)
 
 
 class InputConfigDialogue(QtWidgets.QWidget, inputconfig_widget_class):
+
+    closed = pyqtSignal()
 
     def __init__(self, joystickReader, *args):
         super(InputConfigDialogue, self).__init__(*args)
@@ -171,6 +174,9 @@ class InputConfigDialogue(QtWidgets.QWidget, inputconfig_widget_class):
 
         self._map = {}
         self._saved_open_device = None
+        self._original_input_map = None
+        self._original_input_map_name = None
+        self._config_was_saved = False
 
     @staticmethod
     def _scale(max_value, value):
@@ -224,8 +230,13 @@ class InputConfigDialogue(QtWidgets.QWidget, inputconfig_widget_class):
         self._popup.show()
 
     def _start_configuration(self):
-        self._input.enableRawReading(
-            str(self.inputDeviceSelector.currentText()))
+        device_name = str(self.inputDeviceSelector.currentText())
+        dev = self._input._get_device_from_name(device_name)
+        if dev:
+            self._original_input_map = dev.input_map
+            self._original_input_map_name = getattr(
+                dev, 'input_map_name', None)
+        self._input.enableRawReading(device_name)
         self._input_device_reader.start_reading()
         self._populate_config_dropdown()
         self.profileCombo.setEnabled(True)
@@ -391,6 +402,14 @@ class InputConfigDialogue(QtWidgets.QWidget, inputconfig_widget_class):
         if config_name is None:
             config_name = str(self.profileCombo.currentText())
         ConfigManager().save_config(self._map, config_name)
+        # Update the name on the raw device so the Flight tab shows it.
+        # The actual mapping data is already applied via set_raw_input_map.
+        if self._input._input_device:
+            self._input._input_device.input_map_name = config_name
+            device_name = str(self.inputDeviceSelector.currentText())
+            Config().get("device_config_mapping")[
+                device_name] = config_name
+        self._config_was_saved = True
         self.close()
 
     def showEvent(self, event):
@@ -403,8 +422,15 @@ class InputConfigDialogue(QtWidgets.QWidget, inputconfig_widget_class):
         """Called when dialog is closed"""
         self._input.stop_raw_reading()
         self._input_device_reader.stop_reading()
+        if not self._config_was_saved and self._original_input_map is not None:
+            device_name = str(self.inputDeviceSelector.currentText())
+            dev = self._input._get_device_from_name(device_name)
+            if dev:
+                dev.input_map = self._original_input_map
+                dev.input_map_name = self._original_input_map_name
         # self._input.start_input(self._saved_open_device)
         self._input.resume_input()
+        self.closed.emit()
 
 
 class DeviceReader(QThread):

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -555,7 +555,6 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         # if (len(devs) > 0):
         #    self.device_discovery(devs)
 
-
     def _show_input_device_config_dialog(self):
         self.inputConfig = InputConfigDialogue(self.joystickReader)
         self.inputConfig.closed.connect(self._on_input_config_closed)

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -784,7 +784,8 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
                     device_names.append(dev.name)
                     if dev.supports_mapping:
                         mapping_names.append(
-                            dev.input_map_name if dev.input_map else "No mapping")
+                            ConfigManager().get_display_name(dev.input_map_name)
+                            if dev.input_map else "No mapping")
                     else:
                         mapping_names.append("N/A")
                 else:

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -99,8 +99,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
     disconnectedSignal = pyqtSignal(str)
     linkQualitySignal = pyqtSignal(float)
 
-    gamepad_device_updated = pyqtSignal(str, str, str)
-
+    _gamepad_device_updated = pyqtSignal(str, str, str)
     _input_device_error_signal = pyqtSignal(str)
     _input_discovery_signal = pyqtSignal(object)
     _log_error_signal = pyqtSignal(object, str)
@@ -544,7 +543,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         tab_toolbox.set_preferred_dock_area(area)
 
     def _rescan_devices(self):
-        self.gamepad_device_updated.emit("No input device connected", "—", "—")
+        self._gamepad_device_updated.emit("No input device connected", "—", "—")
         self._menu_devices.clear()
         self._active_device = ""
         self.joystickReader.stop_input()
@@ -797,7 +796,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             device_str = "No input device found"
             mapping_str = "—"
             mux_name = "—"
-        self.gamepad_device_updated.emit(device_str, mapping_str, mux_name)
+        self._gamepad_device_updated.emit(device_str, mapping_str, mux_name)
 
     def _inputdevice_selected(self, checked):
         """Called when a new input device has been selected from the menu. The

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -558,7 +558,12 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
     def _show_input_device_config_dialog(self):
         self.inputConfig = InputConfigDialogue(self.joystickReader)
+        self.inputConfig.closed.connect(self._on_input_config_closed)
         self.inputConfig.show()
+
+    def _on_input_config_closed(self):
+        self._sync_input_map_menus()
+        self._update_input_device_status()
 
     def _show_connect_dialog(self):
         self.logConfigDialogue.show()
@@ -715,6 +720,58 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
                         dev_node.toggled.emit(True)
 
             self._update_input_device_status()
+
+    def _sync_input_map_menus(self):
+        """Sync the Input device menu to reflect the current mapping.
+
+        After the config dialog saves a new mapping, the menu may be
+        missing the new entry and still have the old one checked. Walk
+        every role menu, find the checked device, and make sure its map
+        sub-menu contains and selects the active mapping name.
+        """
+        for menu in self._all_role_menus:
+            role_menu = menu["rolemenu"]
+            for dev_node in role_menu.actions():
+                if not dev_node.isChecked():
+                    continue
+                data = dev_node.data()
+                if data is None or not isinstance(data, tuple):
+                    continue
+                if len(data) < 3:
+                    continue
+                (map_menu, device, _mux_menu) = data
+                if map_menu is None or not device.supports_mapping:
+                    continue
+
+                active_name = getattr(device, 'input_map_name', None)
+                if not active_name:
+                    continue
+
+                # Get the QActionGroup from an existing map action
+                map_actions = map_menu.actions()
+                map_group = None
+                if map_actions:
+                    map_group = map_actions[0].actionGroup()
+
+                # Add a menu entry if the config is new
+                existing = {a.text() for a in map_actions}
+                if active_name not in existing and map_group:
+                    node = QAction(active_name, map_menu,
+                                   checkable=True, enabled=True)
+                    node.toggled.connect(self._inputconfig_selected)
+                    node.setData(dev_node)
+                    map_menu.addAction(node)
+                    map_group.addAction(node)
+
+                # Check the active mapping without triggering
+                # _inputconfig_selected (which would reload the config
+                # from disk and overwrite the live mapping).
+                # Uncheck all first since blockSignals prevents the
+                # exclusive QActionGroup from doing it automatically.
+                for action in map_menu.actions():
+                    action.blockSignals(True)
+                    action.setChecked(action.text() == active_name)
+                    action.blockSignals(False)
 
     def _update_input_device_status(self):
         """Update the gamepad device info in the Flight tab."""

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -61,7 +61,6 @@ from PyQt6.QtGui import QActionGroup
 from PyQt6.QtGui import QShortcut
 from PyQt6.QtGui import QDesktopServices
 from PyQt6.QtGui import QPalette
-from PyQt6.QtWidgets import QLabel
 from PyQt6.QtWidgets import QMenu
 from PyQt6.QtWidgets import QMessageBox
 
@@ -100,6 +99,8 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
     disconnectedSignal = pyqtSignal(str)
     linkQualitySignal = pyqtSignal(float)
 
+    gamepad_device_updated = pyqtSignal(str, str, str)
+
     _input_device_error_signal = pyqtSignal(str)
     _input_discovery_signal = pyqtSignal(object)
     _log_error_signal = pyqtSignal(object, str)
@@ -130,18 +131,8 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self.scanner.interfaceFoundSignal.connect(self.foundInterfaces)
         self.scanner.start()
 
-        # Create and start the Input Reader
-        self._statusbar_label = QLabel("No input-device found, insert one to"
-                                       " fly.")
-        self.statusBar().addWidget(self._statusbar_label)
-
-        #
-        # We use this hacky-trick to find out if we are in dark-mode and
-        # figure out what bgcolor to set from that. We always use the current
-        # palette forgreound.
-        #
-        self.textColor = self._statusbar_label.palette().color(QPalette.ColorRole.WindowText)
-        self.bgColor = self._statusbar_label.palette().color(QPalette.ColorRole.Window)
+        self.textColor = self.palette().color(QPalette.ColorRole.WindowText)
+        self.bgColor = self.palette().color(QPalette.ColorRole.Window)
         self.isDark = self.textColor.value() > self.bgColor.value()
 
         self.joystickReader = JoystickReader()
@@ -552,6 +543,19 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         tab_toolbox = dock_widget.tab_toolbox
         tab_toolbox.set_preferred_dock_area(area)
 
+    def _rescan_devices(self):
+        self.gamepad_device_updated.emit("No input device connected", "—", "—")
+        self._menu_devices.clear()
+        self._active_device = ""
+        self.joystickReader.stop_input()
+
+        # for c in self._menu_mappings.actions():
+        #    c.setEnabled(False)
+        # devs = self.joystickReader.available_devices()
+        # if (len(devs) > 0):
+        #    self.device_discovery(devs)
+
+
     def _show_input_device_config_dialog(self):
         self.inputConfig = InputConfigDialogue(self.joystickReader)
         self.inputConfig.show()
@@ -583,6 +587,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
     def _connected(self):
         self.uiState = UIState.CONNECTED
         self._update_ui_state()
+        self.joystickReader.require_thrust_zero()
 
         Config().set("link_uri", str(self._connectivity_manager.get_interface()))
 
@@ -709,41 +714,34 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
                     if type(dev_node) is QAction and dev_node.isChecked():
                         dev_node.toggled.emit(True)
 
-            self._update_input_device_footer()
+            self._update_input_device_status()
 
-    def _get_dev_status(self, device):
-        msg = "{}".format(device.name)
-        if device.supports_mapping:
-            map_name = "No input mapping"
-            if device.input_map:
-                # Display the friendly name instead of the config file name
-                map_name = ConfigManager().get_display_name(device.input_map_name)
-            msg += " ({})".format(map_name)
-        return msg
-
-    def _update_input_device_footer(self):
-        """Update the footer in the bottom of the UI with status for the
-        input device and its mapping"""
-
-        msg = ""
+    def _update_input_device_status(self):
+        """Update the gamepad device info in the Flight tab."""
 
         if len(self.joystickReader.available_devices()) > 0:
             mux = self.joystickReader._selected_mux
-            msg = "Using {} mux with ".format(mux.name)
-            for key in list(mux._devs.keys())[:-1]:
-                if mux._devs[key]:
-                    msg += "{}, ".format(self._get_dev_status(mux._devs[key]))
+            mux_name = mux.name
+            device_names = []
+            mapping_names = []
+            for dev in mux._devs.values():
+                if dev:
+                    device_names.append(dev.name)
+                    if dev.supports_mapping:
+                        mapping_names.append(
+                            dev.input_map_name if dev.input_map else "No mapping")
+                    else:
+                        mapping_names.append("N/A")
                 else:
-                    msg += "N/A, "
-            # Last item
-            key = list(mux._devs.keys())[-1]
-            if mux._devs[key]:
-                msg += "{}".format(self._get_dev_status(mux._devs[key]))
-            else:
-                msg += "N/A"
+                    device_names.append("N/A")
+                    mapping_names.append("N/A")
+            device_str = ", ".join(device_names)
+            mapping_str = ", ".join(mapping_names)
         else:
-            msg = "No input device found"
-        self._statusbar_label.setText(msg)
+            device_str = "No input device found"
+            mapping_str = "—"
+            mux_name = "—"
+        self.gamepad_device_updated.emit(device_str, mapping_str, mux_name)
 
     def _inputdevice_selected(self, checked):
         """Called when a new input device has been selected from the menu. The
@@ -777,7 +775,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self._mapping_support = self.joystickReader.start_input(
                 device.name,
                 role_in_mux)
-        self._update_input_device_footer()
+        self._update_input_device_status()
 
     def _inputconfig_selected(self, checked):
         """Called when a new configuration has been selected from the menu. The
@@ -790,7 +788,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         selected_mapping = self.sender().config_name
         device = self.sender().data().data()[1]
         self.joystickReader.set_input_map(device.name, selected_mapping)
-        self._update_input_device_footer()
+        self._update_input_device_status()
 
     def device_discovery(self, devs):
         """Called when new devices have been added"""
@@ -870,7 +868,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self._all_role_menus[0]["rolemenu"].actions()[0].setChecked(True)
             logger.info("Select first device")
 
-        self._update_input_device_footer()
+        self._update_input_device_status()
 
     def _open_config_folder(self):
         QDesktopServices.openUrl(

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -173,6 +173,7 @@ class FlightTab(TabToolbox, flight_tab_class):
 
         self._isConnected = False
         self._has_device = False
+        self._has_mapping = False
 
         # Connect UI signals that are in this tab
         self.flightModeCombo.currentIndexChanged.connect(self.flightmodeChange)
@@ -232,11 +233,17 @@ class FlightTab(TabToolbox, flight_tab_class):
             self.gamepadStatusLabel.setText("Lower throttle to arm")
             self.gamepadStatusLabel.setStyleSheet("color: red;")
         else:
-            if self._has_device:
+            if self._has_device and self._has_mapping:
                 self.gamepadStatusLabel.setText("Ready")
+                self.gamepadStatusLabel.setStyleSheet("")
+            elif self._has_device:
+                self.gamepadStatusLabel.setText(
+                    "No mapping selected")
+                self.gamepadStatusLabel.setStyleSheet(
+                    "color: orange;")
             else:
                 self.gamepadStatusLabel.setText("\u2014")
-            self.gamepadStatusLabel.setStyleSheet("")
+                self.gamepadStatusLabel.setStyleSheet("")
 
     def _gamepad_device_updated(self, device, mapping, mux):
         self.gamepadNameLabel.setText(device)
@@ -245,7 +252,15 @@ class FlightTab(TabToolbox, flight_tab_class):
         no_device_strings = ("No input device connected",
                              "No input device found")
         self._has_device = device not in no_device_strings
-        if not self._has_device:
+        if self._has_device:
+            self._has_mapping = "No mapping" not in mapping
+            if not self._has_mapping:
+                self.gamepadStatusLabel.setText(
+                    "No mapping selected")
+                self.gamepadStatusLabel.setStyleSheet(
+                    "color: orange;")
+        else:
+            self._has_mapping = False
             self.gamepadStatusLabel.setText("\u2014")
             self.gamepadStatusLabel.setStyleSheet("")
 

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -92,7 +92,6 @@ class FlightTab(TabToolbox, flight_tab_class):
 
     _log_data_signal = pyqtSignal(int, object, object)
     _pose_data_signal = pyqtSignal(object, object)
-
     _thrust_lock_signal = pyqtSignal(bool)
     _gamepad_device_signal = pyqtSignal(str, str, str)
     _input_updated_signal = pyqtSignal(float, float, float, float)
@@ -102,7 +101,6 @@ class FlightTab(TabToolbox, flight_tab_class):
     _assisted_control_updated_signal = pyqtSignal(bool)
     _heighthold_input_updated_signal = pyqtSignal(float, float, float, float)
     _hover_input_updated_signal = pyqtSignal(float, float, float, float)
-
     _log_error_signal = pyqtSignal(object, str)
 
     # UI_DATA_UPDATE_FPS = 10
@@ -129,7 +127,7 @@ class FlightTab(TabToolbox, flight_tab_class):
             self._thrust_lock_signal.emit)
 
         self._gamepad_device_signal.connect(self._gamepad_device_updated)
-        self._helper.mainUI.gamepad_device_updated.connect(
+        self._helper.mainUI._gamepad_device_updated.connect(
             self._gamepad_device_signal.emit)
 
         self.disconnectedSignal.connect(self.disconnected)

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -172,6 +172,7 @@ class FlightTab(TabToolbox, flight_tab_class):
         self._log_error_signal.connect(self._logging_error)
 
         self._isConnected = False
+        self._has_device = False
 
         # Connect UI signals that are in this tab
         self.flightModeCombo.currentIndexChanged.connect(self.flightmodeChange)
@@ -231,13 +232,22 @@ class FlightTab(TabToolbox, flight_tab_class):
             self.gamepadStatusLabel.setText("Lower throttle to arm")
             self.gamepadStatusLabel.setStyleSheet("color: red;")
         else:
-            self.gamepadStatusLabel.setText("Ready")
+            if self._has_device:
+                self.gamepadStatusLabel.setText("Ready")
+            else:
+                self.gamepadStatusLabel.setText("\u2014")
             self.gamepadStatusLabel.setStyleSheet("")
 
     def _gamepad_device_updated(self, device, mapping, mux):
         self.gamepadNameLabel.setText(device)
         self.gamepadMappingLabel.setText(mapping)
         self.gamepadMuxLabel.setText(mux)
+        no_device_strings = ("No input device connected",
+                             "No input device found")
+        self._has_device = device not in no_device_strings
+        if not self._has_device:
+            self.gamepadStatusLabel.setText("\u2014")
+            self.gamepadStatusLabel.setStyleSheet("")
 
     def _set_limiting_enabled(self, rp_limiting_enabled, yaw_limiting_enabled, thrust_limiting_enabled):
 

--- a/src/cfclient/ui/tabs/flightTab.ui
+++ b/src/cfclient/ui/tabs/flightTab.ui
@@ -361,6 +361,71 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="gamepadBox">
+         <property name="title">
+          <string>Gamepad</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_gamepad">
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_gamepad_status">
+            <property name="text">
+             <string>Status</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLabel" name="gamepadStatusLabel">
+            <property name="text">
+             <string>Ready</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_gamepad_device">
+            <property name="text">
+             <string>Gamepad</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="gamepadNameLabel">
+            <property name="text">
+             <string>No input device found</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_gamepad_mapping">
+            <property name="text">
+             <string>Mapping</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLabel" name="gamepadMappingLabel">
+            <property name="text">
+             <string>—</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_gamepad_mux">
+            <property name="text">
+             <string>Mux</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLabel" name="gamepadMuxLabel">
+            <property name="text">
+             <string>—</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
@@ -649,7 +714,7 @@
                  </sizepolicy>
                 </property>
                 <property name="text">
-                 <string>Gamepad Input</string>
+                 <string>Gamepad Setpoint</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignmentFlag::AlignCenter</set>

--- a/src/cfclient/ui/tabs/flightTab.ui
+++ b/src/cfclient/ui/tabs/flightTab.ui
@@ -376,7 +376,7 @@
           <item row="0" column="1">
            <widget class="QLabel" name="gamepadStatusLabel">
             <property name="text">
-             <string>Ready</string>
+             <string>—</string>
             </property>
            </widget>
           </item>

--- a/src/cfclient/utils/input/__init__.py
+++ b/src/cfclient/utils/input/__init__.py
@@ -201,10 +201,22 @@ class JoystickReader(object):
         throttle is brought to zero by the user. This prevents unexpected
         take-off when connecting with a bad input mapping or after switching
         mappings.
+
+        If thrust is already at zero, the interlock is not engaged to avoid
+        a brief red flash in the UI.
         """
-        if not self._thrust_interlock:
-            self._thrust_interlock = True
-            self.thrust_lock_active.call(True)
+        if self._thrust_interlock:
+            return
+
+        try:
+            data = self._selected_mux.read()
+            if data and data.thrust < 1:
+                return
+        except Exception:
+            pass
+
+        self._thrust_interlock = True
+        self.thrust_lock_active.call(True)
 
     def set_hover_max_height(self, height):
         self._hover_max_height = height


### PR DESCRIPTION
When connecting to a Crazyflie or selecting/changing an input device or mapping, a thrust interlock is now engaged that forces thrust to zero until the physical throttle is brought to zero by the user. This prevents unexpected take-off due to a misconfigured mapping or a non-zero throttle position at connection time.

The gamepad device info (device name, mapping, mux) previously shown in the status bar is now displayed in a dedicated Gamepad section in the Flight tab, alongside an interlock status indicator.

Fixes #775