### PR TITLE
Port FlightTab, PoseLogger, and commander pipeline to cflib2 async API

### DIFF
--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -33,16 +33,19 @@ import sys
 
 import cfclient
 from cfclient.gui import create_task
+from cfclient.ui.pose_logger import PoseLogger
 from cfclient.ui.tab_toolbox import TabToolbox
 import cfclient.ui.tabs
 from cfclient.ui.connectivity_manager import ConnectivityManager
 from cfclient.utils.config import Config
+from cfclient.utils.input import JoystickReader
 from cfclient.utils.ui import UiUtils
 from cflib2 import Crazyflie, LinkContext
 from cflib2.error import DisconnectedError
 from cflib2.toc_cache import FileTocCache
 from PySide6 import QtWidgets
 from PySide6.QtUiTools import loadUiType
+from PySide6.QtCore import Signal
 from PySide6.QtCore import Slot
 from PySide6.QtCore import QDir
 from PySide6.QtCore import QUrl
@@ -70,7 +73,13 @@ logger = logging.getLogger(__name__)
 UIState = ConnectivityManager.UIState
 
 
+class BatteryStates:
+    BATTERY, CHARGING, CHARGED, LOW_POWER = list(range(4))
+
+
 class MainUI(QtWidgets.QMainWindow, main_window_class):
+    _battery_signal = Signal(float, int)
+
     def __init__(self, *args: object) -> None:
         super(MainUI, self).__init__(*args)
         self.setupUi(self)
@@ -81,6 +90,9 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self._toc_cache = FileTocCache(cfclient.config_path + "/cache")
         self._connect_task = None
         self._disconnect_watch_task = None
+        self._battery_task = None
+        self._disable_input = False
+        self._loop = None
 
         # Restore window size if present in the config file
         try:
@@ -104,7 +116,10 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self.menuItemConfInputDevice.setEnabled(False)
         self.logConfigAction.setEnabled(False)
         self._menu_inputdevice.setEnabled(False)
+
+        # Emergency stop button
         self.esButton.setEnabled(False)
+        self.esButton.clicked.connect(self._emergency_stop)
 
         self._set_address()
 
@@ -124,16 +139,33 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self.batteryBar.setTextVisible(False)
         self.linkQualityBar.setTextVisible(False)
 
+        # Input device reader (joystick)
+        self._joystick_reader = JoystickReader()
+
+        # Connect joystick input to Crazyflie commander
+        self._joystick_reader.input_updated.add_callback(
+            self._send_setpoint)
+        self._joystick_reader.assisted_input_updated.add_callback(
+            self._send_velocity_world)
+        self._joystick_reader.heighthold_input_updated.add_callback(
+            self._send_zdistance)
+        self._joystick_reader.hover_input_updated.add_callback(
+            self._send_hover)
+
         # pluginhelper for tabs
+        self._pose_logger = PoseLogger()
+        cfclient.ui.pluginhelper.inputDeviceReader = self._joystick_reader
+        cfclient.ui.pluginhelper.pose_logger = self._pose_logger
         cfclient.ui.pluginhelper.connectivity_manager = self._connectivity_manager
         cfclient.ui.pluginhelper.mainUI = self
 
         self._connectivity_manager.set_address(self.address.value())
 
         self._initial_scan = True
-        QTimer.singleShot(
-            0, lambda: self._scan(self._connectivity_manager.get_address())
-        )
+        QTimer.singleShot(0, self._on_event_loop_ready)
+
+        # Battery monitoring signal
+        self._battery_signal.connect(self._update_battery)
 
         # Tabs and toolboxes
         self.tabs_menu_item = QMenu("Tabs", self.menuView)
@@ -270,6 +302,84 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self, area: Qt.DockWidgetArea, tab_toolbox: TabToolbox
     ) -> None:
         tab_toolbox.set_preferred_dock_area(area)
+
+    # --- Event loop ---
+
+    def _on_event_loop_ready(self):
+        self._loop = asyncio.get_event_loop()
+        self._scan(self._connectivity_manager.get_address())
+
+    # --- Commander pipeline ---
+
+    async def _safe_send(self, coro):
+        try:
+            await coro
+        except DisconnectedError:
+            pass
+
+    def _send_setpoint(self, roll, pitch, yaw, thrust):
+        cf = self.cf
+        if self._disable_input or cf is None or self._loop is None:
+            return
+        asyncio.run_coroutine_threadsafe(
+            self._safe_send(
+                cf.commander().send_setpoint_rpyt(
+                    roll, pitch, yaw, int(thrust)
+                )
+            ),
+            self._loop,
+        )
+
+    def _send_velocity_world(self, vx, vy, vz, yawrate):
+        cf = self.cf
+        if self._disable_input or cf is None or self._loop is None:
+            return
+        asyncio.run_coroutine_threadsafe(
+            self._safe_send(
+                cf.commander().send_setpoint_velocity_world(
+                    vx, vy, vz, yawrate
+                )
+            ),
+            self._loop,
+        )
+
+    def _send_zdistance(self, roll, pitch, yawrate, zdistance):
+        cf = self.cf
+        if self._disable_input or cf is None or self._loop is None:
+            return
+        asyncio.run_coroutine_threadsafe(
+            self._safe_send(
+                cf.commander().send_setpoint_zdistance(
+                    roll, pitch, yawrate, zdistance
+                )
+            ),
+            self._loop,
+        )
+
+    def _send_hover(self, vx, vy, yawrate, zdistance):
+        cf = self.cf
+        if self._disable_input or cf is None or self._loop is None:
+            return
+        asyncio.run_coroutine_threadsafe(
+            self._safe_send(
+                cf.commander().send_setpoint_hover(
+                    vx, vy, yawrate, zdistance
+                )
+            ),
+            self._loop,
+        )
+
+    def disable_input(self, disable):
+        """Disable gamepad input to allow a tab to send setpoints directly."""
+        self._disable_input = disable
+
+    # --- Emergency stop ---
+
+    def _emergency_stop(self):
+        if self.cf is not None:
+            create_task(
+                self.cf.localization().emergency().send_emergency_stop()
+            )
 
     # --- Address ---
 
@@ -408,12 +518,50 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self._update_ui_state()
 
     def _notify_tabs_connected(self) -> None:
+        self._pose_logger.start(self.cf)
+        self._battery_task = create_task(self._stream_battery(self.cf))
         for tab_toolbox in self.loaded_tab_toolboxes.values():
             tab_toolbox.connected(self.cf)
 
     def _notify_tabs_disconnected(self) -> None:
+        self._pose_logger.stop()
+        if self._battery_task is not None:
+            self._battery_task.cancel()
+            self._battery_task = None
         for tab_toolbox in self.loaded_tab_toolboxes.values():
             tab_toolbox.disconnected()
+
+    async def _stream_battery(self, cf):
+        log = cf.log()
+        block = await log.create_block()
+        await block.add_variable("pm.vbat")
+        await block.add_variable("pm.state")
+        stream = await block.start(1000)
+        try:
+            while True:
+                data = await stream.next()
+                self._battery_signal.emit(
+                    data.data["pm.vbat"], int(data.data["pm.state"])
+                )
+        finally:
+            try:
+                await stream.stop()
+            except DisconnectedError:
+                pass
+
+    def _update_battery(self, vbat, state):
+        self.batteryBar.setValue(int(vbat * 1000))
+
+        color = UiUtils.COLOR_BLUE
+        # TODO firmware reports fully-charged state as 'Battery',
+        # rather than 'Charged'
+        if state in [BatteryStates.CHARGING, BatteryStates.CHARGED]:
+            color = UiUtils.COLOR_GREEN
+        elif state == BatteryStates.LOW_POWER:
+            color = UiUtils.COLOR_RED
+
+        self.batteryBar.setStyleSheet(UiUtils.progressbar_stylesheet(color))
+        self._aff_volts.setText("%.3f" % vbat)
 
     # --- UI state ---
 
@@ -427,13 +575,18 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
                 ConnectivityManager.UIState.DISCONNECTED
             )
             self.batteryBar.setValue(3000)
+            # TODO: cflib2 does not expose link quality statistics
             self.linkQualityBar.setValue(0)
+            self.esButton.setEnabled(False)
+            self.esButton.setStyleSheet("")
         elif self.uiState == UIState.CONNECTED:
             s = "Connected on %s" % self._connectivity_manager.get_interface()
             self.setWindowTitle(s)
             self.menuItemConnect.setText("Disconnect")
             self.menuItemConnect.setEnabled(True)
             self._connectivity_manager.set_state(ConnectivityManager.UIState.CONNECTED)
+            self.esButton.setEnabled(True)
+            self.esButton.setStyleSheet("background-color: red")
         elif self.uiState == UIState.CONNECTING:
             s = "Connecting to {} ...".format(
                 self._connectivity_manager.get_interface()

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -317,49 +317,62 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         except DisconnectedError:
             pass
 
+    def _commander_future_cb(self, future):
+        """Log unexpected exceptions from commander coroutines."""
+        try:
+            future.result()
+        except DisconnectedError:
+            pass
+        except Exception:
+            logger.error("Unhandled exception in commander coroutine", exc_info=True)
+
     def _send_setpoint(self, roll, pitch, yaw, thrust):
         cf = self.cf
         if self._disable_input or cf is None or self._loop is None:
             return
-        asyncio.run_coroutine_threadsafe(
+        future = asyncio.run_coroutine_threadsafe(
             self._safe_send(
                 cf.commander().send_setpoint_rpyt(roll, pitch, yaw, int(thrust))
             ),
             self._loop,
         )
+        future.add_done_callback(self._commander_future_cb)
 
     def _send_velocity_world(self, vx, vy, vz, yawrate):
         cf = self.cf
         if self._disable_input or cf is None or self._loop is None:
             return
-        asyncio.run_coroutine_threadsafe(
+        future = asyncio.run_coroutine_threadsafe(
             self._safe_send(
                 cf.commander().send_setpoint_velocity_world(vx, vy, vz, yawrate)
             ),
             self._loop,
         )
+        future.add_done_callback(self._commander_future_cb)
 
     def _send_zdistance(self, roll, pitch, yawrate, zdistance):
         cf = self.cf
         if self._disable_input or cf is None or self._loop is None:
             return
-        asyncio.run_coroutine_threadsafe(
+        future = asyncio.run_coroutine_threadsafe(
             self._safe_send(
                 cf.commander().send_setpoint_zdistance(roll, pitch, yawrate, zdistance)
             ),
             self._loop,
         )
+        future.add_done_callback(self._commander_future_cb)
 
     def _send_hover(self, vx, vy, yawrate, zdistance):
         cf = self.cf
         if self._disable_input or cf is None or self._loop is None:
             return
-        asyncio.run_coroutine_threadsafe(
+        future = asyncio.run_coroutine_threadsafe(
             self._safe_send(
                 cf.commander().send_setpoint_hover(vx, vy, yawrate, zdistance)
             ),
             self._loop,
         )
+        future.add_done_callback(self._commander_future_cb)
 
     def disable_input(self, disable):
         """Disable gamepad input to allow a tab to send setpoints directly."""
@@ -537,8 +550,8 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
                 )
         finally:
             try:
-                await stream.stop()
-            except DisconnectedError:
+                await asyncio.shield(stream.stop())
+            except (DisconnectedError, asyncio.CancelledError):
                 pass
 
     def _update_battery(self, vbat, state):

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -143,14 +143,14 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self._joystick_reader = JoystickReader()
 
         # Connect joystick input to Crazyflie commander
-        self._joystick_reader.input_updated.add_callback(
-            self._send_setpoint)
+        self._joystick_reader.input_updated.add_callback(self._send_setpoint)
         self._joystick_reader.assisted_input_updated.add_callback(
-            self._send_velocity_world)
+            self._send_velocity_world
+        )
         self._joystick_reader.heighthold_input_updated.add_callback(
-            self._send_zdistance)
-        self._joystick_reader.hover_input_updated.add_callback(
-            self._send_hover)
+            self._send_zdistance
+        )
+        self._joystick_reader.hover_input_updated.add_callback(self._send_hover)
 
         # pluginhelper for tabs
         self._pose_logger = PoseLogger()
@@ -323,9 +323,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             return
         asyncio.run_coroutine_threadsafe(
             self._safe_send(
-                cf.commander().send_setpoint_rpyt(
-                    roll, pitch, yaw, int(thrust)
-                )
+                cf.commander().send_setpoint_rpyt(roll, pitch, yaw, int(thrust))
             ),
             self._loop,
         )
@@ -336,9 +334,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             return
         asyncio.run_coroutine_threadsafe(
             self._safe_send(
-                cf.commander().send_setpoint_velocity_world(
-                    vx, vy, vz, yawrate
-                )
+                cf.commander().send_setpoint_velocity_world(vx, vy, vz, yawrate)
             ),
             self._loop,
         )
@@ -349,9 +345,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             return
         asyncio.run_coroutine_threadsafe(
             self._safe_send(
-                cf.commander().send_setpoint_zdistance(
-                    roll, pitch, yawrate, zdistance
-                )
+                cf.commander().send_setpoint_zdistance(roll, pitch, yawrate, zdistance)
             ),
             self._loop,
         )
@@ -362,9 +356,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             return
         asyncio.run_coroutine_threadsafe(
             self._safe_send(
-                cf.commander().send_setpoint_hover(
-                    vx, vy, yawrate, zdistance
-                )
+                cf.commander().send_setpoint_hover(vx, vy, yawrate, zdistance)
             ),
             self._loop,
         )
@@ -377,9 +369,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
     def _emergency_stop(self):
         if self.cf is not None:
-            create_task(
-                self.cf.localization().emergency().send_emergency_stop()
-            )
+            create_task(self.cf.localization().emergency().send_emergency_stop())
 
     # --- Address ---
 
@@ -500,9 +490,11 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self.cf = None
             self.uiState = UIState.DISCONNECTED
             self._update_ui_state()
-            QMessageBox.critical(
-                self, "Communication failure", f"Connection lost to {uri}: {reason}"
-            )
+            msg = QMessageBox(self)
+            msg.setIcon(QMessageBox.Icon.Critical)
+            msg.setWindowTitle("Communication failure")
+            msg.setText(f"Connection lost to {uri}: {reason}")
+            msg.show()
         except asyncio.CancelledError:
             pass
 

--- a/src/cfclient/ui/pluginhelper.py
+++ b/src/cfclient/ui/pluginhelper.py
@@ -28,21 +28,23 @@
 """
 Used for passing objects to tabs and toolboxes.
 """
+
 import os
 
-__author__ = 'Bitcraze AB'
-__all__ = ['PluginHelper']
+__author__ = "Bitcraze AB"
+__all__ = ["PluginHelper"]
 
 
-class PluginHelper():
+class PluginHelper:
     """Used for passing objects to tabs and toolboxes"""
 
     def __init__(self):
         self.cf = None
         self.menu = None
+        self.inputDeviceReader = None
         self.logConfigReader = None
         self.mainUI = None
         self.plotTab = None
         self.pose_logger = None
         self.connectivity_manager = None
-        self.current_folder = os.path.expanduser('~')
+        self.current_folder = os.path.expanduser("~")

--- a/src/cfclient/ui/pose_logger.py
+++ b/src/cfclient/ui/pose_logger.py
@@ -7,7 +7,7 @@
 #  +------+    / /_/ / / /_/ /__/ /  / /_/ / / /_/  __/
 #   ||  ||    /_____/_/\__/\___/_/   \__,_/ /___/\___/
 #
-#  Copyright (C) 2021 Bitcraze AB
+#  Copyright (C) 2021-2025 Bitcraze AB
 #
 #  Crazyflie Nano Quadcopter Client
 #
@@ -28,40 +28,39 @@
 """
 Sets up logging for the the full pose of the Crazyflie
 """
+
 import logging
 import math
 
-from cflib.crazyflie import Crazyflie
-from cflib.crazyflie.log import LogConfig
-from cflib.utils.callbacks import Caller
+from cflib2 import DisconnectedError
 
-__author__ = 'Bitcraze AB'
-__all__ = ['PoseLogger']
+from cfclient.gui import create_task
+from cfclient.utils.callbacks import Caller
+
+__author__ = "Bitcraze AB"
+__all__ = ["PoseLogger"]
 
 logger = logging.getLogger(__name__)
 
 
 class PoseLogger:
-    LOG_NAME_ESTIMATE_X = 'stateEstimate.x'
-    LOG_NAME_ESTIMATE_Y = 'stateEstimate.y'
-    LOG_NAME_ESTIMATE_Z = 'stateEstimate.z'
-    LOG_NAME_ESTIMATE_ROLL = 'stateEstimate.roll'
-    LOG_NAME_ESTIMATE_PITCH = 'stateEstimate.pitch'
-    LOG_NAME_ESTIMATE_YAW = 'stateEstimate.yaw'
+    LOG_NAME_ESTIMATE_X = "stateEstimate.x"
+    LOG_NAME_ESTIMATE_Y = "stateEstimate.y"
+    LOG_NAME_ESTIMATE_Z = "stateEstimate.z"
+    LOG_NAME_ESTIMATE_ROLL = "stateEstimate.roll"
+    LOG_NAME_ESTIMATE_PITCH = "stateEstimate.pitch"
+    LOG_NAME_ESTIMATE_YAW = "stateEstimate.yaw"
     NO_POSE = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
 
-    def __init__(self, cf: Crazyflie) -> None:
-        self._cf = cf
-        self._cf.connected.add_callback(self._connected)
-        self._cf.disconnected.add_callback(self._disconnected)
-
+    def __init__(self) -> None:
         self.data_received_cb = Caller()
         self.error_cb = Caller()
 
-        # The pose is an array containing
+        # The pose is a tuple containing
         # X, Y, Z, roll, pitch, yaw
         # roll, pitch and yaw in degrees
         self.pose = self.NO_POSE
+        self._stream_task = None
 
     @property
     def position(self):
@@ -76,41 +75,48 @@ class PoseLogger:
     @property
     def rpy_rad(self):
         """Get the roll, pitch and yaw of the full pose in radians"""
-        return [math.radians(self.pose[3]), math.radians(self.pose[4]), math.radians(self.pose[5])]
+        return [
+            math.radians(self.pose[3]),
+            math.radians(self.pose[4]),
+            math.radians(self.pose[5]),
+        ]
 
-    def _connected(self, link_uri) -> None:
-        logConf = LogConfig("Pose", 40)
-        logConf.add_variable(self.LOG_NAME_ESTIMATE_X, "float")
-        logConf.add_variable(self.LOG_NAME_ESTIMATE_Y, "float")
-        logConf.add_variable(self.LOG_NAME_ESTIMATE_Z, "float")
-        logConf.add_variable(self.LOG_NAME_ESTIMATE_ROLL, "float")
-        logConf.add_variable(self.LOG_NAME_ESTIMATE_PITCH, "float")
-        logConf.add_variable(self.LOG_NAME_ESTIMATE_YAW, "float")
+    def start(self, cf):
+        """Start streaming pose data from the Crazyflie."""
+        self._stream_task = create_task(self._stream_loop(cf))
 
-        try:
-            self._cf.log.add_config(logConf)
-            logConf.data_received_cb.add_callback(self._data_received)
-            logConf.error_cb.add_callback(self._error)
-            logConf.start()
-        except KeyError as e:
-            logger.warning(str(e))
-        except AttributeError as e:
-            logger.warning(str(e))
-
-    def _disconnected(self, link_uri) -> None:
+    def stop(self):
+        """Stop streaming pose data."""
+        if self._stream_task is not None:
+            self._stream_task.cancel()
+            self._stream_task = None
         self.pose = self.NO_POSE
 
-    def _data_received(self, timestamp, data, logconf) -> None:
-        self.pose = (
-            data[self.LOG_NAME_ESTIMATE_X],
-            data[self.LOG_NAME_ESTIMATE_Y],
-            data[self.LOG_NAME_ESTIMATE_Z],
-            data[self.LOG_NAME_ESTIMATE_ROLL],
-            data[self.LOG_NAME_ESTIMATE_PITCH],
-            data[self.LOG_NAME_ESTIMATE_YAW],
-        )
+    async def _stream_loop(self, cf):
+        log = cf.log()
+        block = await log.create_block()
+        await block.add_variable(self.LOG_NAME_ESTIMATE_X)
+        await block.add_variable(self.LOG_NAME_ESTIMATE_Y)
+        await block.add_variable(self.LOG_NAME_ESTIMATE_Z)
+        await block.add_variable(self.LOG_NAME_ESTIMATE_ROLL)
+        await block.add_variable(self.LOG_NAME_ESTIMATE_PITCH)
+        await block.add_variable(self.LOG_NAME_ESTIMATE_YAW)
 
-        self.data_received_cb.call(self, self.pose)
-
-    def _error(self, log_conf, msg) -> None:
-        self.error_cb.call(self, msg)
+        stream = await block.start(40)  # 40ms period
+        try:
+            while True:
+                data = await stream.next()
+                self.pose = (
+                    data.data[self.LOG_NAME_ESTIMATE_X],
+                    data.data[self.LOG_NAME_ESTIMATE_Y],
+                    data.data[self.LOG_NAME_ESTIMATE_Z],
+                    data.data[self.LOG_NAME_ESTIMATE_ROLL],
+                    data.data[self.LOG_NAME_ESTIMATE_PITCH],
+                    data.data[self.LOG_NAME_ESTIMATE_YAW],
+                )
+                self.data_received_cb.call(self, self.pose)
+        finally:
+            try:
+                await stream.stop()
+            except DisconnectedError:
+                pass

--- a/src/cfclient/ui/pose_logger.py
+++ b/src/cfclient/ui/pose_logger.py
@@ -29,6 +29,7 @@
 Sets up logging for the the full pose of the Crazyflie
 """
 
+import asyncio
 import logging
 import math
 
@@ -117,6 +118,6 @@ class PoseLogger:
                 self.data_received_cb.call(self, self.pose)
         finally:
             try:
-                await stream.stop()
-            except DisconnectedError:
+                await asyncio.shield(stream.stop())
+            except (DisconnectedError, asyncio.CancelledError):
                 pass

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -196,7 +196,7 @@ class FlightTab(TabToolbox, flight_tab_class):
         self.commanderDownButton.clicked.connect(
             lambda: self._flight_command(CommanderAction.DOWN)
         )
-        self._update_flight_commander(False)
+        self.commanderBox.setEnabled(False)
 
         # Supervisor
         self._supervisor_info_bitfield = 0
@@ -353,7 +353,8 @@ class FlightTab(TabToolbox, flight_tab_class):
 
             if data[self.LOG_NAME_CAN_FLY] != self._can_fly_deprecated:
                 self._can_fly_deprecated = data[self.LOG_NAME_CAN_FLY]
-                self._update_flight_commander(True)
+                if self._cf is not None:
+                    create_task(self._update_flight_commander(self._cf))
 
             if self.LOG_NAME_SUPERVISOR_INFO in data:
                 self._supervisor_info_bitfield = data[self.LOG_NAME_SUPERVISOR_INFO]
@@ -477,24 +478,16 @@ class FlightTab(TabToolbox, flight_tab_class):
                 self.armButton.setStyleSheet("")
                 self.armButton.setEnabled(False)
 
-    def _update_flight_commander(self, connected):
+    async def _update_flight_commander(self, cf):
         self.commanderBox.setToolTip(str())
-        if not connected:
-            self.commanderBox.setEnabled(False)
-            return
+        self.commanderBox.setEnabled(False)
 
         if self._can_fly_deprecated == 0:
-            self.commanderBox.setEnabled(False)
             self.commanderBox.setToolTip(
                 "The Crazyflie reports that flight is not possible"
             )
             return
 
-        # Deck param check is done asynchronously in
-        # _update_flight_commander_async
-        self.commanderBox.setEnabled(False)
-
-    async def _update_flight_commander_async(self, cf):
         param = cf.param()
 
         #                  flowV1    flowV2     LightHouse       LPS
@@ -517,7 +510,6 @@ class FlightTab(TabToolbox, flight_tab_class):
             self.commanderBox.setToolTip(
                 "You need a positioning deck to use Command Based Flight"
             )
-            self.commanderBox.setEnabled(False)
             return
 
         # To prevent conflicting commands from the controller and
@@ -526,7 +518,6 @@ class FlightTab(TabToolbox, flight_tab_class):
             self.commanderBox.setToolTip(
                 "Cannot use both a controller and Command Based Flight"
             )
-            self.commanderBox.setEnabled(False)
             return
 
         self.commanderBox.setEnabled(True)
@@ -582,7 +573,7 @@ class FlightTab(TabToolbox, flight_tab_class):
         await self._populate_assisted_mode_dropdown(cf)
 
         # Update flight commander (reads deck params)
-        await self._update_flight_commander_async(cf)
+        await self._update_flight_commander(cf)
 
         self._update_supervisor_and_arming(True)
 
@@ -641,7 +632,7 @@ class FlightTab(TabToolbox, flight_tab_class):
         self._assist_mode_combo.setEnabled(False)
         self._assist_mode_combo.clear()
 
-        self._update_flight_commander(False)
+        self.commanderBox.setEnabled(False)
 
         self._supervisor_info_bitfield = 0
         self._update_supervisor_and_arming(False)

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -29,6 +29,7 @@
 The flight control tab shows telemetry data and flight settings.
 """
 
+import asyncio
 import logging
 from enum import Enum
 
@@ -120,7 +121,9 @@ class FlightTab(TabToolbox, flight_tab_class):
         self._input_updated_signal.connect(self.updateInputControl)
         self._rp_trim_updated_signal.connect(self.calUpdateFromInput)
         self._emergency_stop_updated_signal.connect(self.updateEmergencyStop)
-        self._arm_updated_signal.connect(lambda: self.updateArm(from_controller=True))
+        self._arm_updated_signal.connect(
+            lambda _enabled: self.updateArm(from_controller=True)
+        )
         self._heighthold_input_updated_signal.connect(self._heighthold_input_updated)
         self._hover_input_updated_signal.connect(self._hover_input_updated)
         self._assisted_control_updated_signal.connect(self._assisted_control_updated)
@@ -514,7 +517,8 @@ class FlightTab(TabToolbox, flight_tab_class):
 
         # To prevent conflicting commands from the controller and
         # the flight panel
-        if JoystickReader().available_devices():
+        reader = self._helper.inputDeviceReader
+        if reader is not None and reader.available_devices():
             self.commanderBox.setToolTip(
                 "Cannot use both a controller and Command Based Flight"
             )
@@ -549,8 +553,8 @@ class FlightTab(TabToolbox, flight_tab_class):
                 self._log_data_received(data.timestamp, data.data)
         finally:
             try:
-                await stream.stop()
-            except DisconnectedError:
+                await asyncio.shield(stream.stop())
+            except (DisconnectedError, asyncio.CancelledError):
                 pass
 
     async def _setup_after_connect(self, cf):

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -34,25 +34,23 @@ from enum import Enum
 
 from PySide6.QtUiTools import loadUiType
 from PySide6.QtCore import Qt, Signal
-from PySide6.QtWidgets import QMessageBox
 
 import cfclient
+from cflib2 import DisconnectedError
+from cfclient.gui import create_task
 from cfclient.ui.widgets.ai import AttitudeIndicator
-
-from cflib.crazyflie.log import LogConfig
 
 from cfclient.utils.config import Config
 from cfclient.utils.input import JoystickReader
 
 from cfclient.ui.tab_toolbox import TabToolbox
 
-__author__ = 'Bitcraze AB'
-__all__ = ['FlightTab']
+__author__ = "Bitcraze AB"
+__all__ = ["FlightTab"]
 
 logger = logging.getLogger(__name__)
 
-flight_tab_class = loadUiType(cfclient.module_path +
-                                  "/ui/tabs/flightTab.ui")[0]
+flight_tab_class = loadUiType(cfclient.module_path + "/ui/tabs/flightTab.ui")[0]
 
 MAX_THRUST = 65536.0
 
@@ -90,7 +88,6 @@ class CommanderAction(Enum):
 class FlightTab(TabToolbox, flight_tab_class):
     uiSetupReadySignal = Signal()
 
-    _log_data_signal = Signal(int, object, object)
     _pose_data_signal = Signal(object, object)
 
     _input_updated_signal = Signal(float, float, float, float)
@@ -101,74 +98,71 @@ class FlightTab(TabToolbox, flight_tab_class):
     _heighthold_input_updated_signal = Signal(float, float, float, float)
     _hover_input_updated_signal = Signal(float, float, float, float)
 
-    _log_error_signal = Signal(object, str)
-
-    # UI_DATA_UPDATE_FPS = 10
-
-    connectionFinishedSignal = Signal(str)
-    disconnectedSignal = Signal(str)
-
     _limiting_updated = Signal(bool, bool, bool)
 
-    LOG_NAME_THRUST = 'stabilizer.thrust'
-    LOG_NAME_MOTOR_1 = 'motor.m1'
-    LOG_NAME_MOTOR_2 = 'motor.m2'
-    LOG_NAME_MOTOR_3 = 'motor.m3'
-    LOG_NAME_MOTOR_4 = 'motor.m4'
-    LOG_NAME_CAN_FLY = 'sys.canfly'
-    LOG_NAME_SUPERVISOR_INFO = 'supervisor.info'
+    LOG_NAME_THRUST = "stabilizer.thrust"
+    LOG_NAME_MOTOR_1 = "motor.m1"
+    LOG_NAME_MOTOR_2 = "motor.m2"
+    LOG_NAME_MOTOR_3 = "motor.m3"
+    LOG_NAME_MOTOR_4 = "motor.m4"
+    LOG_NAME_CAN_FLY = "sys.canfly"
+    LOG_NAME_SUPERVISOR_INFO = "supervisor.info"
 
     def __init__(self, helper):
-        super(FlightTab, self).__init__(helper, 'Flight Control')
+        super(FlightTab, self).__init__(helper, "Flight Control")
         self.setupUi(self)
 
-        self.disconnectedSignal.connect(self.disconnected)
-        self.connectionFinishedSignal.connect(self.connected)
-        # Incomming signals
-        self._helper.cf.connected.add_callback(
-            self.connectionFinishedSignal.emit)
-        self._helper.cf.disconnected.add_callback(self.disconnectedSignal.emit)
+        self._cf = None
+        self._log_task = None
+        self._setup_task = None
+        self._isConnected = False
 
         self._input_updated_signal.connect(self.updateInputControl)
-        self._helper.inputDeviceReader.input_updated.add_callback(
-            self._input_updated_signal.emit)
         self._rp_trim_updated_signal.connect(self.calUpdateFromInput)
-        self._helper.inputDeviceReader.rp_trim_updated.add_callback(
-            self._rp_trim_updated_signal.emit)
         self._emergency_stop_updated_signal.connect(self.updateEmergencyStop)
-        self._helper.inputDeviceReader.emergency_stop_updated.add_callback(
-            self._emergency_stop_updated_signal.emit)
         self._arm_updated_signal.connect(lambda: self.updateArm(from_controller=True))
-        self._helper.inputDeviceReader.arm_updated.add_callback(self._arm_updated_signal.emit)
+        self._heighthold_input_updated_signal.connect(self._heighthold_input_updated)
+        self._hover_input_updated_signal.connect(self._hover_input_updated)
+        self._assisted_control_updated_signal.connect(self._assisted_control_updated)
 
-        self._helper.inputDeviceReader.heighthold_input_updated.add_callback(
-            self._heighthold_input_updated_signal.emit)
-        self._heighthold_input_updated_signal.connect(
-            self._heighthold_input_updated)
-        self._helper.inputDeviceReader.hover_input_updated.add_callback(
-            self._hover_input_updated_signal.emit)
-        self._hover_input_updated_signal.connect(
-            self._hover_input_updated)
-
-        self._helper.inputDeviceReader.assisted_control_updated.add_callback(
-            self._assisted_control_updated_signal.emit)
-
-        self._assisted_control_updated_signal.connect(
-            self._assisted_control_updated)
+        if self._helper.inputDeviceReader is not None:
+            self._helper.inputDeviceReader.input_updated.add_callback(
+                self._input_updated_signal.emit
+            )
+            self._helper.inputDeviceReader.rp_trim_updated.add_callback(
+                self._rp_trim_updated_signal.emit
+            )
+            self._helper.inputDeviceReader.emergency_stop_updated.add_callback(
+                self._emergency_stop_updated_signal.emit
+            )
+            self._helper.inputDeviceReader.arm_updated.add_callback(
+                self._arm_updated_signal.emit
+            )
+            self._helper.inputDeviceReader.heighthold_input_updated.add_callback(
+                self._heighthold_input_updated_signal.emit
+            )
+            self._helper.inputDeviceReader.hover_input_updated.add_callback(
+                self._hover_input_updated_signal.emit
+            )
+            self._helper.inputDeviceReader.assisted_control_updated.add_callback(
+                self._assisted_control_updated_signal.emit
+            )
+            self._helper.inputDeviceReader.limiting_updated.add_callback(
+                self._limiting_updated.emit
+            )
 
         self._pose_data_signal.connect(self._pose_data_received)
-        self._log_data_signal.connect(self._log_data_received)
-
-        self._log_error_signal.connect(self._logging_error)
-
-        self._isConnected = False
 
         # Connect UI signals that are in this tab
         self.flightModeCombo.currentIndexChanged.connect(self.flightmodeChange)
         self.minThrust.valueChanged.connect(self.minMaxThrustChanged)
         self.maxThrust.valueChanged.connect(self.minMaxThrustChanged)
-        self.thrustLoweringSlewRateLimit.valueChanged.connect(self.thrustLoweringSlewRateLimitChanged)
-        self.slewEnableLimit.valueChanged.connect(self.thrustLoweringSlewRateLimitChanged)
+        self.thrustLoweringSlewRateLimit.valueChanged.connect(
+            self.thrustLoweringSlewRateLimitChanged
+        )
+        self.slewEnableLimit.valueChanged.connect(
+            self.thrustLoweringSlewRateLimitChanged
+        )
         self.targetCalRoll.valueChanged.connect(self._trim_roll_changed)
         self.targetCalPitch.valueChanged.connect(self._trim_pitch_changed)
         self.maxAngle.valueChanged.connect(self.maxAngleChanged)
@@ -178,14 +172,30 @@ class FlightTab(TabToolbox, flight_tab_class):
 
         # Command Based Flight Control
         self._can_fly_deprecated = 0
-        self.commanderTakeOffButton.clicked.connect(lambda: self._flight_command(CommanderAction.TAKE_OFF))
-        self.commanderLandButton.clicked.connect(lambda: self._flight_command(CommanderAction.LAND))
-        self.commanderLeftButton.clicked.connect(lambda: self._flight_command(CommanderAction.LEFT))
-        self.commanderRightButton.clicked.connect(lambda: self._flight_command(CommanderAction.RIGHT))
-        self.commanderForwardButton.clicked.connect(lambda: self._flight_command(CommanderAction.FORWARD))
-        self.commanderBackButton.clicked.connect(lambda: self._flight_command(CommanderAction.BACK))
-        self.commanderUpButton.clicked.connect(lambda: self._flight_command(CommanderAction.UP))
-        self.commanderDownButton.clicked.connect(lambda: self._flight_command(CommanderAction.DOWN))
+        self.commanderTakeOffButton.clicked.connect(
+            lambda: self._flight_command(CommanderAction.TAKE_OFF)
+        )
+        self.commanderLandButton.clicked.connect(
+            lambda: self._flight_command(CommanderAction.LAND)
+        )
+        self.commanderLeftButton.clicked.connect(
+            lambda: self._flight_command(CommanderAction.LEFT)
+        )
+        self.commanderRightButton.clicked.connect(
+            lambda: self._flight_command(CommanderAction.RIGHT)
+        )
+        self.commanderForwardButton.clicked.connect(
+            lambda: self._flight_command(CommanderAction.FORWARD)
+        )
+        self.commanderBackButton.clicked.connect(
+            lambda: self._flight_command(CommanderAction.BACK)
+        )
+        self.commanderUpButton.clicked.connect(
+            lambda: self._flight_command(CommanderAction.UP)
+        )
+        self.commanderDownButton.clicked.connect(
+            lambda: self._flight_command(CommanderAction.DOWN)
+        )
         self._update_flight_commander(False)
 
         # Supervisor
@@ -194,10 +204,6 @@ class FlightTab(TabToolbox, flight_tab_class):
         self._update_supervisor_and_arming(False)
 
         self.uiSetupReady()
-
-        self._helper.cf.param.add_update_callback(group="imu_sensors", cb=self._set_available_sensors)
-
-        self._helper.cf.param.all_updated.add_callback(self._all_params_updated)
 
         self.logAltHold = None
 
@@ -211,13 +217,16 @@ class FlightTab(TabToolbox, flight_tab_class):
         self._tf_state = 0
 
         # Connect callbacks for input device limiting of roll/pitch/yaw/thrust
-        self._helper.inputDeviceReader.limiting_updated.add_callback(self._limiting_updated.emit)
         self._limiting_updated.connect(self._set_limiting_enabled)
 
-        self._helper.pose_logger.data_received_cb.add_callback(self._pose_data_signal.emit)
+        if self._helper.pose_logger is not None:
+            self._helper.pose_logger.data_received_cb.add_callback(
+                self._pose_data_signal.emit
+            )
 
-    def _set_limiting_enabled(self, rp_limiting_enabled, yaw_limiting_enabled, thrust_limiting_enabled):
-
+    def _set_limiting_enabled(
+        self, rp_limiting_enabled, yaw_limiting_enabled, thrust_limiting_enabled
+    ):
         self.targetCalRoll.setEnabled(rp_limiting_enabled)
         self.targetCalPitch.setEnabled(rp_limiting_enabled)
 
@@ -227,14 +236,18 @@ class FlightTab(TabToolbox, flight_tab_class):
         self.maxThrust.setEnabled(thrust_limiting_enabled and advanced_is_enabled)
         self.minThrust.setEnabled(thrust_limiting_enabled and advanced_is_enabled)
         self.slewEnableLimit.setEnabled(thrust_limiting_enabled and advanced_is_enabled)
-        self.thrustLoweringSlewRateLimit.setEnabled(thrust_limiting_enabled and advanced_is_enabled)
+        self.thrustLoweringSlewRateLimit.setEnabled(
+            thrust_limiting_enabled and advanced_is_enabled
+        )
 
     def thrustToPercentage(self, thrust):
-        return ((thrust / MAX_THRUST) * 100.0)
+        return (thrust / MAX_THRUST) * 100.0
 
     def uiSetupReady(self):
-        flightComboIndex = self.flightModeCombo.findText(Config().get("flightmode"), Qt.MatchFlag.MatchFixedString)
-        if (flightComboIndex < 0):
+        flightComboIndex = self.flightModeCombo.findText(
+            Config().get("flightmode"), Qt.MatchFlag.MatchFixedString
+        )
+        if flightComboIndex < 0:
             self.flightModeCombo.setCurrentIndex(0)
             self.flightModeCombo.currentIndexChanged.emit(0)
         else:
@@ -242,35 +255,92 @@ class FlightTab(TabToolbox, flight_tab_class):
             self.flightModeCombo.currentIndexChanged.emit(flightComboIndex)
 
     def _flight_command(self, action):
-        current_z = self._helper.pose_logger.position[2]
+        if self._cf is not None:
+            create_task(self._async_flight_command(action))
+
+    async def _async_flight_command(self, action):
+        pose_logger = self._helper.pose_logger
+        current_z = pose_logger.position[2] if pose_logger else 0.0
         move_dist = 0.5
         move_vel = 0.5
 
+        hlc = self._cf.high_level_commander()
+        param = self._cf.param()
+
         if action == CommanderAction.TAKE_OFF:
-            self._helper.cf.param.set_value('commander.enHighLevel', '1')
+            await param.set("commander.enHighLevel", 1)
             z_target = current_z + move_dist
-            self._helper.cf.high_level_commander.takeoff(z_target, move_dist / move_vel)
+            await hlc.take_off(z_target, None, move_dist / move_vel, None)
         elif action == CommanderAction.LAND:
-            self._helper.cf.high_level_commander.land(0, current_z / move_vel)
+            await hlc.land(0, None, current_z / move_vel, None)
         elif action == CommanderAction.LEFT:
-            self._helper.cf.high_level_commander.go_to(0, move_dist, 0, 0, move_dist / move_vel, relative=True)
+            await hlc.go_to(
+                0,
+                move_dist,
+                0,
+                0,
+                move_dist / move_vel,
+                relative=True,
+                linear=False,
+                group_mask=None,
+            )
         elif action == CommanderAction.RIGHT:
-            self._helper.cf.high_level_commander.go_to(0, -move_dist, 0, 0, move_dist / move_vel, relative=True)
+            await hlc.go_to(
+                0,
+                -move_dist,
+                0,
+                0,
+                move_dist / move_vel,
+                relative=True,
+                linear=False,
+                group_mask=None,
+            )
         elif action == CommanderAction.FORWARD:
-            self._helper.cf.high_level_commander.go_to(move_dist, 0, 0, 0, move_dist / move_vel, relative=True)
+            await hlc.go_to(
+                move_dist,
+                0,
+                0,
+                0,
+                move_dist / move_vel,
+                relative=True,
+                linear=False,
+                group_mask=None,
+            )
         elif action == CommanderAction.BACK:
-            self._helper.cf.high_level_commander.go_to(-move_dist, 0, 0, 0, move_dist / move_vel, relative=True)
+            await hlc.go_to(
+                -move_dist,
+                0,
+                0,
+                0,
+                move_dist / move_vel,
+                relative=True,
+                linear=False,
+                group_mask=None,
+            )
         elif action == CommanderAction.UP:
-            self._helper.cf.high_level_commander.go_to(0, 0, move_dist, 0, move_dist / move_vel, relative=True)
+            await hlc.go_to(
+                0,
+                0,
+                move_dist,
+                0,
+                move_dist / move_vel,
+                relative=True,
+                linear=False,
+                group_mask=None,
+            )
         elif action == CommanderAction.DOWN:
-            self._helper.cf.high_level_commander.go_to(0, 0, -move_dist, 0, move_dist / move_vel, relative=True)
+            await hlc.go_to(
+                0,
+                0,
+                -move_dist,
+                0,
+                move_dist / move_vel,
+                relative=True,
+                linear=False,
+                group_mask=None,
+            )
 
-    def _logging_error(self, log_conf, msg):
-        QMessageBox.about(self, "Log error",
-                          "Error when starting log config [%s]: %s" % (
-                              log_conf.name, msg))
-
-    def _log_data_received(self, timestamp, data, logconf):
+    def _log_data_received(self, timestamp, data):
         if self.isVisible() and self._isConnected:
             self.actualM1.setValue(data[self.LOG_NAME_MOTOR_1])
             self.actualM2.setValue(data[self.LOG_NAME_MOTOR_2])
@@ -278,7 +348,8 @@ class FlightTab(TabToolbox, flight_tab_class):
             self.actualM4.setValue(data[self.LOG_NAME_MOTOR_4])
 
             self.estimateThrust.setText(
-                "%.2f%%" % self.thrustToPercentage(data[self.LOG_NAME_THRUST]))
+                "%.2f%%" % self.thrustToPercentage(data[self.LOG_NAME_THRUST])
+            )
 
             if data[self.LOG_NAME_CAN_FLY] != self._can_fly_deprecated:
                 self._can_fly_deprecated = data[self.LOG_NAME_CAN_FLY]
@@ -306,10 +377,12 @@ class FlightTab(TabToolbox, flight_tab_class):
             self.ai.setRollPitch(-roll, pitch, self.is_visible())
 
     def _heighthold_input_updated(self, roll, pitch, yaw, height):
-        if (self.isVisible() and
-                (self._helper.inputDeviceReader.get_assisted_control() ==
-                 self._helper.inputDeviceReader.ASSISTED_CONTROL_HEIGHTHOLD)):
-
+        if self._helper.inputDeviceReader is None:
+            return
+        if self.isVisible() and (
+            self._helper.inputDeviceReader.get_assisted_control()
+            == self._helper.inputDeviceReader.ASSISTED_CONTROL_HEIGHTHOLD
+        ):
             self.targetRoll.setText(("%0.2f deg" % roll))
             self.targetPitch.setText(("%0.2f deg" % pitch))
             self.targetYaw.setText(("%0.2f deg/s" % yaw))
@@ -319,10 +392,12 @@ class FlightTab(TabToolbox, flight_tab_class):
             self._change_input_labels(using_hover_assist=False)
 
     def _hover_input_updated(self, vx, vy, yaw, height):
-        if (self.isVisible() and
-                (self._helper.inputDeviceReader.get_assisted_control() ==
-                 self._helper.inputDeviceReader.ASSISTED_CONTROL_HOVER)):
-
+        if self._helper.inputDeviceReader is None:
+            return
+        if self.isVisible() and (
+            self._helper.inputDeviceReader.get_assisted_control()
+            == self._helper.inputDeviceReader.ASSISTED_CONTROL_HOVER
+        ):
             self.targetRoll.setText(("%0.2f m/s" % vy))
             self.targetPitch.setText(("%0.2f m/s" % vx))
             self.targetYaw.setText(("%0.2f deg/s" % yaw))
@@ -333,9 +408,9 @@ class FlightTab(TabToolbox, flight_tab_class):
 
     def _change_input_labels(self, using_hover_assist):
         if using_hover_assist:
-            pitch, roll, yaw = 'Velocity X', 'Velocity Y', 'Velocity Z'
+            pitch, roll, yaw = "Velocity X", "Velocity Y", "Velocity Z"
         else:
-            pitch, roll, yaw = 'Pitch', 'Roll', 'Yaw'
+            pitch, roll, yaw = "Pitch", "Roll", "Yaw"
 
         self.inputPitchLabel.setText(pitch)
         self.inputRollLabel.setText(roll)
@@ -410,62 +485,106 @@ class FlightTab(TabToolbox, flight_tab_class):
 
         if self._can_fly_deprecated == 0:
             self.commanderBox.setEnabled(False)
-            self.commanderBox.setToolTip('The Crazyflie reports that flight is not possible')
+            self.commanderBox.setToolTip(
+                "The Crazyflie reports that flight is not possible"
+            )
             return
 
-        # We cannot know if we have a positioning deck until we get params
-        if not self._helper.cf.param.is_updated:
-            self.commanderBox.setEnabled(False)
-            return
+        # Deck param check is done asynchronously in
+        # _update_flight_commander_async
+        self.commanderBox.setEnabled(False)
+
+    async def _update_flight_commander_async(self, cf):
+        param = cf.param()
 
         #                  flowV1    flowV2     LightHouse       LPS
-        position_decks = ['bcFlow', 'bcFlow2', 'bcLighthouse4', 'bcLoco', 'bcDWM1000']
+        position_decks = [
+            "bcFlow",
+            "bcFlow2",
+            "bcLighthouse4",
+            "bcLoco",
+            "bcDWM1000",
+        ]
+        has_position_deck = False
         for deck in position_decks:
-            if int(self._helper.cf.param.values['deck'][deck]) == 1:
-                self.commanderBox.setEnabled(True)
-                break
-        else:
-            self.commanderBox.setToolTip('You need a positioning deck to use Command Based Flight')
-            self.commanderBox.setEnabled(False)
-            return
+            name = f"deck.{deck}"
+            if name in param.names():
+                if int(await param.get(name)) == 1:
+                    has_position_deck = True
+                    break
 
-        # To prevent conflicting commands from the controller and the flight panel
-        if JoystickReader().available_devices():
+        if not has_position_deck:
             self.commanderBox.setToolTip(
-                'Cannot use both a controller and Command Based Flight'
+                "You need a positioning deck to use Command Based Flight"
             )
             self.commanderBox.setEnabled(False)
             return
 
-    def connected(self, linkURI):
-        self._isConnected = True
-        # MOTOR & THRUST
-        lg = LogConfig("Motors", Config().get("ui_update_period"))
-        lg.add_variable(self.LOG_NAME_THRUST, "uint16_t")
-        lg.add_variable(self.LOG_NAME_MOTOR_1)
-        lg.add_variable(self.LOG_NAME_MOTOR_2)
-        lg.add_variable(self.LOG_NAME_MOTOR_3)
-        lg.add_variable(self.LOG_NAME_MOTOR_4)
-        lg.add_variable(self.LOG_NAME_CAN_FLY)
+        # To prevent conflicting commands from the controller and
+        # the flight panel
+        if JoystickReader().available_devices():
+            self.commanderBox.setToolTip(
+                "Cannot use both a controller and Command Based Flight"
+            )
+            self.commanderBox.setEnabled(False)
+            return
 
-        # Add supervisor info if it exists to keep backwards compatibility
-        if self._helper.cf.log.toc.get_element_by_complete_name(self.LOG_NAME_SUPERVISOR_INFO):
-            lg.add_variable(self.LOG_NAME_SUPERVISOR_INFO)
-        # Full supervisor info available after V7, hide supervisor info for earlier versions
-        update_supervisor_info = self._helper.cf.platform.get_protocol_version() >= 7
+        self.commanderBox.setEnabled(True)
+
+    def connected(self, cf):
+        self._cf = cf
+        self._isConnected = True
+        self._log_task = create_task(self._stream_motors(cf))
+        self._setup_task = create_task(self._setup_after_connect(cf))
+
+    async def _stream_motors(self, cf):
+        log = cf.log()
+        block = await log.create_block()
+        await block.add_variable(self.LOG_NAME_THRUST)
+        await block.add_variable(self.LOG_NAME_MOTOR_1)
+        await block.add_variable(self.LOG_NAME_MOTOR_2)
+        await block.add_variable(self.LOG_NAME_MOTOR_3)
+        await block.add_variable(self.LOG_NAME_MOTOR_4)
+        await block.add_variable(self.LOG_NAME_CAN_FLY)
+
+        if self.LOG_NAME_SUPERVISOR_INFO in log.names():
+            await block.add_variable(self.LOG_NAME_SUPERVISOR_INFO)
+
+        period_ms = Config().get("ui_update_period")
+        stream = await block.start(period_ms)
+        try:
+            while True:
+                data = await stream.next()
+                self._log_data_received(data.timestamp, data.data)
+        finally:
+            try:
+                await stream.stop()
+            except DisconnectedError:
+                pass
+
+    async def _setup_after_connect(self, cf):
+        param = cf.param()
+        platform = cf.platform()
+
+        # Protocol version check for supervisor UI
+        protocol_version = await platform.get_protocol_version()
+        update_supervisor_info = protocol_version >= 7
         self._supervisor_state.setVisible(update_supervisor_info)
         self._supervisor_label1.setVisible(update_supervisor_info)
         self._supervisor_label2.setVisible(update_supervisor_info)
 
-        try:
-            self._helper.cf.log.add_config(lg)
-            lg.data_received_cb.add_callback(self._log_data_signal.emit)
-            lg.error_cb.add_callback(self._log_error_signal.emit)
-            lg.start()
-        except KeyError as e:
-            logger.warning(str(e))
-        except AttributeError as e:
-            logger.warning(str(e))
+        # Check imu_sensors
+        if "imu_sensors.HMC5883L" in param.names():
+            val = await param.get("imu_sensors.HMC5883L")
+            self._set_available_sensors("imu_sensors.HMC5883L", val)
+
+        # Populate assisted mode dropdown (reads deck params)
+        await self._populate_assisted_mode_dropdown(cf)
+
+        # Update flight commander (reads deck params)
+        await self._update_flight_commander_async(cf)
+
+        self._update_supervisor_and_arming(True)
 
     def _enable_estimators(self, should_enable):
         self.estimateX.setEnabled(should_enable)
@@ -474,13 +593,22 @@ class FlightTab(TabToolbox, flight_tab_class):
 
     def _set_available_sensors(self, name, available):
         logger.debug("[%s]: %s", name, available)
-        available = eval(available)
+        available = int(available)
 
         self._enable_estimators(True)
-        self._helper.inputDeviceReader.set_alt_hold_available(available)
+        if self._helper.inputDeviceReader is not None:
+            self._helper.inputDeviceReader.set_alt_hold_available(available)
 
-    def disconnected(self, linkURI):
+    def disconnected(self):
+        if self._log_task is not None:
+            self._log_task.cancel()
+            self._log_task = None
+        if self._setup_task is not None:
+            self._setup_task.cancel()
+            self._setup_task = None
+        self._cf = None
         self._isConnected = False
+
         self.ai.setRollPitch(0, 0)
         self.actualM1.setValue(0)
         self.actualM2.setValue(0)
@@ -505,7 +633,8 @@ class FlightTab(TabToolbox, flight_tab_class):
 
         try:
             self._assist_mode_combo.currentIndexChanged.disconnect(
-                self._assist_mode_changed)
+                self._assist_mode_changed
+            )
         except TypeError:
             # Signal was not connected
             pass
@@ -542,46 +671,55 @@ class FlightTab(TabToolbox, flight_tab_class):
         return bool(self._supervisor_info_bitfield & 0x0080)
 
     def minMaxThrustChanged(self):
+        if self._helper.inputDeviceReader is None:
+            return
         self._helper.inputDeviceReader.min_thrust = self.minThrust.value()
         self._helper.inputDeviceReader.max_thrust = self.maxThrust.value()
-        if (self.isInCrazyFlightmode is True):
+        if self.isInCrazyFlightmode is True:
             Config().set("min_thrust", self.minThrust.value())
             Config().set("max_thrust", self.maxThrust.value())
 
     def thrustLoweringSlewRateLimitChanged(self):
+        if self._helper.inputDeviceReader is None:
+            return
         self._helper.inputDeviceReader.thrust_slew_rate = (
-            self.thrustLoweringSlewRateLimit.value())
-        self._helper.inputDeviceReader.thrust_slew_limit = (
-            self.slewEnableLimit.value())
-        if (self.isInCrazyFlightmode is True):
+            self.thrustLoweringSlewRateLimit.value()
+        )
+        self._helper.inputDeviceReader.thrust_slew_limit = self.slewEnableLimit.value()
+        if self.isInCrazyFlightmode is True:
             Config().set("slew_limit", self.slewEnableLimit.value())
             Config().set("slew_rate", self.thrustLoweringSlewRateLimit.value())
 
     def maxYawRateChanged(self):
         logger.debug("MaxYawrate changed to %d", self.maxYawRate.value())
-        self._helper.inputDeviceReader.max_yaw_rate = self.maxYawRate.value()
-        if (self.isInCrazyFlightmode is True):
+        if self._helper.inputDeviceReader is not None:
+            self._helper.inputDeviceReader.max_yaw_rate = self.maxYawRate.value()
+        if self.isInCrazyFlightmode is True:
             Config().set("max_yaw", self.maxYawRate.value())
 
     def maxAngleChanged(self):
         logger.debug("MaxAngle changed to %d", self.maxAngle.value())
-        self._helper.inputDeviceReader.max_rp_angle = self.maxAngle.value()
-        if (self.isInCrazyFlightmode is True):
+        if self._helper.inputDeviceReader is not None:
+            self._helper.inputDeviceReader.max_rp_angle = self.maxAngle.value()
+        if self.isInCrazyFlightmode is True:
             Config().set("max_rp", self.maxAngle.value())
 
     def _trim_pitch_changed(self, value):
         logger.debug("Pitch trim updated to [%f]" % value)
-        self._helper.inputDeviceReader.trim_pitch = value
+        if self._helper.inputDeviceReader is not None:
+            self._helper.inputDeviceReader.trim_pitch = value
         Config().set("trim_pitch", value)
 
     def _trim_roll_changed(self, value):
         logger.debug("Roll trim updated to [%f]" % value)
-        self._helper.inputDeviceReader.trim_roll = value
+        if self._helper.inputDeviceReader is not None:
+            self._helper.inputDeviceReader.trim_roll = value
         Config().set("trim_roll", value)
 
     def calUpdateFromInput(self, rollCal, pitchCal):
-        logger.debug("Trim changed on joystick: roll=%.2f, pitch=%.2f",
-                     rollCal, pitchCal)
+        logger.debug(
+            "Trim changed on joystick: roll=%.2f, pitch=%.2f", rollCal, pitchCal
+        )
         self.targetCalRoll.setValue(rollCal)
         self.targetCalPitch.setValue(pitchCal)
 
@@ -589,8 +727,7 @@ class FlightTab(TabToolbox, flight_tab_class):
         self.targetRoll.setText(("%0.2f deg" % roll))
         self.targetPitch.setText(("%0.2f deg" % pitch))
         self.targetYaw.setText(("%0.2f deg/s" % yaw))
-        self.targetThrust.setText(("%0.2f %%" %
-                                   self.thrustToPercentage(thrust)))
+        self.targetThrust.setText(("%0.2f %%" % self.thrustToPercentage(thrust)))
         self.thrustProgress.setValue(int(thrust))
 
         self._change_input_labels(using_hover_assist=False)
@@ -602,53 +739,56 @@ class FlightTab(TabToolbox, flight_tab_class):
         self.M4label.setEnabled(enabled)
 
     def emergencyStopStringWithText(self, text):
-        return ("<html><head/><body><p>"
-                "<span style='font-weight:600; color:#7b0005;'>{}</span>"
-                "</p></body></html>".format(text))
+        return (
+            "<html><head/><body><p>"
+            "<span style='font-weight:600; color:#7b0005;'>{}</span>"
+            "</p></body></html>".format(text)
+        )
 
     def updateEmergencyStop(self, emergencyStop):
         if emergencyStop:
             self.setMotorLabelsEnabled(False)
-            self._helper.cf.loc.send_emergency_stop()
-            # TODO krri disarm?
+            if self._cf is not None:
+                create_task(self._cf.localization().emergency().send_emergency_stop())
         else:
             self.setMotorLabelsEnabled(True)
 
     def updateArm(self, from_controller=False):
+        if self._cf is not None:
+            create_task(self._async_update_arm(from_controller))
+
+    async def _async_update_arm(self, from_controller):
         if self._is_flying() and not from_controller:
-            self._helper.cf.loc.send_emergency_stop()
+            await self._cf.localization().emergency().send_emergency_stop()
         elif self._is_crashed():
-            self._helper.cf.platform.send_crash_recovery_request()
+            await self._cf.platform().send_crash_recovery_request()
         elif self._is_armed():
-            self._helper.cf.platform.send_arming_request(False)
+            await self._cf.platform().send_arming_request(False)
         elif self._can_arm():
             self.armButton.setStyleSheet("background-color: orange")
-            self._helper.cf.platform.send_arming_request(True)
+            await self._cf.platform().send_arming_request(True)
 
     def flightmodeChange(self, item):
         Config().set("flightmode", str(self.flightModeCombo.itemText(item)))
-        logger.debug("Changed flightmode to %s",
-                     self.flightModeCombo.itemText(item))
+        logger.debug("Changed flightmode to %s", self.flightModeCombo.itemText(item))
         self.isInCrazyFlightmode = False
-        if (item == 0):  # Normal
+        if item == 0:  # Normal
             self.maxAngle.setValue(Config().get("normal_max_rp"))
             self.maxThrust.setValue(Config().get("normal_max_thrust"))
             self.minThrust.setValue(Config().get("normal_min_thrust"))
             self.slewEnableLimit.setValue(Config().get("normal_slew_limit"))
-            self.thrustLoweringSlewRateLimit.setValue(
-                Config().get("normal_slew_rate"))
+            self.thrustLoweringSlewRateLimit.setValue(Config().get("normal_slew_rate"))
             self.maxYawRate.setValue(Config().get("normal_max_yaw"))
-        if (item == 1):  # Advanced
+        if item == 1:  # Advanced
             self.maxAngle.setValue(Config().get("max_rp"))
             self.maxThrust.setValue(Config().get("max_thrust"))
             self.minThrust.setValue(Config().get("min_thrust"))
             self.slewEnableLimit.setValue(Config().get("slew_limit"))
-            self.thrustLoweringSlewRateLimit.setValue(
-                Config().get("slew_rate"))
+            self.thrustLoweringSlewRateLimit.setValue(Config().get("slew_rate"))
             self.maxYawRate.setValue(Config().get("max_yaw"))
             self.isInCrazyFlightmode = True
 
-        if (item == 0):
+        if item == 0:
             newState = False
         else:
             newState = True
@@ -662,71 +802,97 @@ class FlightTab(TabToolbox, flight_tab_class):
     def _assist_mode_changed(self, item):
         mode = None
 
-        if (item == 0):  # Altitude hold
+        if item == 0:  # Altitude hold
             mode = JoystickReader.ASSISTED_CONTROL_ALTHOLD
-        if (item == 1):  # Position hold
+        if item == 1:  # Position hold
             mode = JoystickReader.ASSISTED_CONTROL_POSHOLD
-        if (item == 2):  # Position hold
+        if item == 2:  # Height hold
             mode = JoystickReader.ASSISTED_CONTROL_HEIGHTHOLD
-        if (item == 3):  # Position hold
+        if item == 3:  # Hover
             mode = JoystickReader.ASSISTED_CONTROL_HOVER
 
-        self._helper.inputDeviceReader.set_assisted_control(mode)
+        if self._helper.inputDeviceReader is not None:
+            self._helper.inputDeviceReader.set_assisted_control(mode)
         Config().set("assistedControl", mode)
 
     def _assisted_control_updated(self, enabled):
-        if self._helper.inputDeviceReader.get_assisted_control() == \
-                JoystickReader.ASSISTED_CONTROL_POSHOLD:
+        if self._helper.inputDeviceReader is None:
+            return
+        if (
+            self._helper.inputDeviceReader.get_assisted_control()
+            == JoystickReader.ASSISTED_CONTROL_POSHOLD
+        ):
             self.targetThrust.setEnabled(not enabled)
             self.targetRoll.setEnabled(not enabled)
             self.targetPitch.setEnabled(not enabled)
-        elif ((self._helper.inputDeviceReader.get_assisted_control() ==
-                JoystickReader.ASSISTED_CONTROL_HEIGHTHOLD) or
-                (self._helper.inputDeviceReader.get_assisted_control() ==
-                 JoystickReader.ASSISTED_CONTROL_HOVER)):
+        elif (
+            self._helper.inputDeviceReader.get_assisted_control()
+            == JoystickReader.ASSISTED_CONTROL_HEIGHTHOLD
+        ) or (
+            self._helper.inputDeviceReader.get_assisted_control()
+            == JoystickReader.ASSISTED_CONTROL_HOVER
+        ):
             self.targetThrust.setEnabled(not enabled)
             self.targetHeight.setEnabled(enabled)
-            print('Chaning enable for target height: %s' % enabled)
         else:
-            self._helper.cf.param.set_value("flightmode.althold", int(enabled))
+            if self._cf is not None:
+                create_task(self._cf.param().set("flightmode.althold", int(enabled)))
 
-    def _all_params_updated(self):
-        self._populate_assisted_mode_dropdown()
-        self._update_flight_commander(True)
-        self._update_supervisor_and_arming(True)
+    async def _populate_assisted_mode_dropdown(self, cf):
+        param = cf.param()
 
-    def _populate_assisted_mode_dropdown(self):
         self._assist_mode_combo.addItem("Altitude hold", 0)
         self._assist_mode_combo.addItem("Position hold", 1)
         self._assist_mode_combo.addItem("Height hold", 2)
         self._assist_mode_combo.addItem("Hover", 3)
 
         # Add the tooltips to the assist-mode items.
-        self._assist_mode_combo.setItemData(0, TOOLTIP_ALTITUDE_HOLD, Qt.ItemDataRole.ToolTipRole)
-        self._assist_mode_combo.setItemData(1, TOOLTIP_POSITION_HOLD, Qt.ItemDataRole.ToolTipRole)
-        self._assist_mode_combo.setItemData(2, TOOLTIP_HEIGHT_HOLD, Qt.ItemDataRole.ToolTipRole)
-        self._assist_mode_combo.setItemData(3, TOOLTIP_HOVER, Qt.ItemDataRole.ToolTipRole)
+        self._assist_mode_combo.setItemData(
+            0, TOOLTIP_ALTITUDE_HOLD, Qt.ItemDataRole.ToolTipRole
+        )
+        self._assist_mode_combo.setItemData(
+            1, TOOLTIP_POSITION_HOLD, Qt.ItemDataRole.ToolTipRole
+        )
+        self._assist_mode_combo.setItemData(
+            2, TOOLTIP_HEIGHT_HOLD, Qt.ItemDataRole.ToolTipRole
+        )
+        self._assist_mode_combo.setItemData(
+            3, TOOLTIP_HOVER, Qt.ItemDataRole.ToolTipRole
+        )
 
         heightHoldPossible = False
         hoverPossible = False
 
-        if int(self._helper.cf.param.values["deck"]["bcZRanger"]) == 1:
+        if (
+            "deck.bcZRanger" in param.names()
+            and int(await param.get("deck.bcZRanger")) == 1
+        ):
             heightHoldPossible = True
-            self._helper.inputDeviceReader.set_hover_max_height(1.0)
+            if self._helper.inputDeviceReader is not None:
+                self._helper.inputDeviceReader.set_hover_max_height(1.0)
 
-        if int(self._helper.cf.param.values["deck"]["bcZRanger2"]) == 1:
+        if (
+            "deck.bcZRanger2" in param.names()
+            and int(await param.get("deck.bcZRanger2")) == 1
+        ):
             heightHoldPossible = True
-            self._helper.inputDeviceReader.set_hover_max_height(2.0)
+            if self._helper.inputDeviceReader is not None:
+                self._helper.inputDeviceReader.set_hover_max_height(2.0)
 
-        if int(self._helper.cf.param.values["deck"]["bcFlow"]) == 1:
+        if "deck.bcFlow" in param.names() and int(await param.get("deck.bcFlow")) == 1:
             heightHoldPossible = True
             hoverPossible = True
-            self._helper.inputDeviceReader.set_hover_max_height(1.0)
+            if self._helper.inputDeviceReader is not None:
+                self._helper.inputDeviceReader.set_hover_max_height(1.0)
 
-        if int(self._helper.cf.param.values["deck"]["bcFlow2"]) == 1:
+        if (
+            "deck.bcFlow2" in param.names()
+            and int(await param.get("deck.bcFlow2")) == 1
+        ):
             heightHoldPossible = True
             hoverPossible = True
-            self._helper.inputDeviceReader.set_hover_max_height(2.0)
+            if self._helper.inputDeviceReader is not None:
+                self._helper.inputDeviceReader.set_hover_max_height(2.0)
 
         if not heightHoldPossible:
             self._assist_mode_combo.model().item(2).setEnabled(False)
@@ -738,8 +904,7 @@ class FlightTab(TabToolbox, flight_tab_class):
         else:
             self._assist_mode_combo.model().item(0).setEnabled(False)
 
-        self._assist_mode_combo.currentIndexChanged.connect(
-            self._assist_mode_changed)
+        self._assist_mode_combo.currentIndexChanged.connect(self._assist_mode_changed)
         self._assist_mode_combo.setEnabled(True)
 
         try:
@@ -758,8 +923,7 @@ class FlightTab(TabToolbox, flight_tab_class):
                 self._assist_mode_combo.currentIndexChanged.emit(2)
             else:
                 self._assist_mode_combo.setCurrentIndex(assistmodeComboIndex)
-                self._assist_mode_combo.currentIndexChanged.emit(
-                                                    assistmodeComboIndex)
+                self._assist_mode_combo.currentIndexChanged.emit(assistmodeComboIndex)
         except KeyError:
             defaultOption = 0
             if hoverPossible:

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -493,7 +493,6 @@ class FlightTab(TabToolbox, flight_tab_class):
 
         param = cf.param()
 
-        #                  flowV1    flowV2     LightHouse       LPS
         position_decks = [
             "bcFlow",
             "bcFlow2",

--- a/src/cfclient/ui/tabs/__init__.py
+++ b/src/cfclient/ui/tabs/__init__.py
@@ -33,7 +33,7 @@ it into the UI when it is started.
 # from .ConsoleTab import ConsoleTab
 # from .CrtpSharkToolbox import CrtpSharkToolbox
 # from .ExampleTab import ExampleTab
-# from .FlightTab import FlightTab
+from .FlightTab import FlightTab
 # from .GpsTab import GpsTab
 # from .LEDRingTab import LEDRingTab
 # from .LogBlockTab import LogBlockTab
@@ -52,7 +52,7 @@ __all__ = []
 available = [
     # ConsoleTab,
     # ExampleTab,
-    # FlightTab,
+    FlightTab,
     # GpsTab,
     # LEDRingTab,
     # ColorLEDTab,

--- a/src/cfclient/ui/widgets/ai.py
+++ b/src/cfclient/ui/widgets/ai.py
@@ -35,8 +35,8 @@ from PySide6 import QtGui
 from PySide6 import QtWidgets
 from PySide6.QtCore import Qt
 
-__author__ = 'Bitcraze AB'
-__all__ = ['AttitudeIndicator']
+__author__ = "Bitcraze AB"
+__all__ = ["AttitudeIndicator"]
 
 
 class AttitudeIndicator(QtWidgets.QWidget):
@@ -98,7 +98,7 @@ class AttitudeIndicator(QtWidgets.QWidget):
         qp.translate(-w / 2, -h / 2)
         qp.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing)
 
-        font = QtGui.QFont('Serif', 7, QtGui.QFont.Weight.Light)
+        font = QtGui.QFont("Serif", 7, QtGui.QFont.Weight.Light)
         qp.setFont(font)
 
         # Draw the blue
@@ -123,22 +123,35 @@ class AttitudeIndicator(QtWidgets.QWidget):
                     length = 0.35 * w
                     if i != 0:
                         if ofset == 0:
-                            qp.drawText(int((w / 2) + (length / 2) + (w * 0.06)),
-                                        pos, "{}".format(-i / 10))
-                            qp.drawText(int((w / 2) - (length / 2) - (w * 0.08)),
-                                        pos, "{}".format(-i / 10))
+                            qp.drawText(
+                                int((w / 2) + (length / 2) + (w * 0.06)),
+                                pos,
+                                "{}".format(-i / 10),
+                            )
+                            qp.drawText(
+                                int((w / 2) - (length / 2) - (w * 0.08)),
+                                pos,
+                                "{}".format(-i / 10),
+                            )
                         else:
-                            qp.drawText(int((w / 2) + (length / 2) + (w * 0.06)),
-                                        pos, "{}".format(i / 10))
-                            qp.drawText(int((w / 2) - (length / 2) - (w * 0.08)),
-                                        pos, "{}".format(i / 10))
+                            qp.drawText(
+                                int((w / 2) + (length / 2) + (w * 0.06)),
+                                pos,
+                                "{}".format(i / 10),
+                            )
+                            qp.drawText(
+                                int((w / 2) - (length / 2) - (w * 0.08)),
+                                pos,
+                                "{}".format(i / 10),
+                            )
                 elif i % 50 == 0:
                     length = 0.2 * w
                 else:
                     length = 0.1 * w
 
-                qp.drawLine(int((w / 2) - (length / 2)), pos,
-                            int((w / 2) + (length / 2)), pos)
+                qp.drawLine(
+                    int((w / 2) - (length / 2)), pos, int((w / 2) + (length / 2)), pos
+                )
 
         qp.setWorldMatrixEnabled(False)
 
@@ -155,7 +168,7 @@ class AttitudeIndicator(QtWidgets.QWidget):
         qp.setBrush(QtGui.QColor(255, 255, 255))
         qp.setPen(pen)
         fh = int(max(7, h / 50))
-        font = QtGui.QFont('Sans', fh, QtGui.QFont.Weight.Light)
+        font = QtGui.QFont("Sans", fh, QtGui.QFont.Weight.Light)
         qp.setFont(font)
         qp.resetTransform()
 
@@ -166,8 +179,7 @@ class AttitudeIndicator(QtWidgets.QWidget):
 
         if self.hover:
             # target height (center)
-            qp.drawText(
-                w - fh * 10, int(fh / 2), str(round(self.hoverTargetHeight, 2)))
+            qp.drawText(w - fh * 10, int(fh / 2), str(round(self.hoverTargetHeight, 2)))
             diff = round(self.hoverHeight - self.hoverTargetHeight, 2)
             pos_y = -h / 6 * diff
 
@@ -190,8 +202,8 @@ class AttitudeIndicator(QtWidgets.QWidget):
 
 
 if __name__ == "__main__":
-    class Example(QtWidgets.QWidget):
 
+    class Example(QtWidgets.QWidget):
         def __init__(self):
             super(Example, self).__init__()
 
@@ -204,10 +216,10 @@ if __name__ == "__main__":
             self.wid.setRoll((roll / 10.0) - 180.0)
 
         def updateTarget(self, target):
-            self.wid.setHover(500 + target / 10.)
+            self.wid.setHover(500 + target / 10.0)
 
         def updateBaro(self, height):
-            self.wid.setBaro(500 + height / 10.)
+            self.wid.setBaro(500 + height / 10.0)
 
         def initUI(self):
             vbox = QtWidgets.QVBoxLayout()
@@ -251,7 +263,7 @@ if __name__ == "__main__":
             self.setLayout(hbox)
 
             self.setGeometry(50, 50, 510, 510)
-            self.setWindowTitle('Attitude Indicator')
+            self.setWindowTitle("Attitude Indicator")
             self.show()
 
         def changeValue(self, value):
@@ -263,5 +275,5 @@ if __name__ == "__main__":
         Example()
         sys.exit(app.exec())
 
-    if __name__ == '__main__':
+    if __name__ == "__main__":
         main()

--- a/src/cfclient/ui/widgets/super_slider.py
+++ b/src/cfclient/ui/widgets/super_slider.py
@@ -25,15 +25,14 @@ Slider widget with advanced features
 """
 
 from PySide6 import QtWidgets, QtCore
-from cflib.utils.callbacks import Caller
+from cfclient.utils.callbacks import Caller
 
 
-__author__ = 'Bitcraze AB'
-__all__ = ['SuperSlider']
+__author__ = "Bitcraze AB"
+__all__ = ["SuperSlider"]
 
 
 class SuperSlider(QtWidgets.QWidget):
-
     def __init__(self, min: float, max: float, value: float):
         super(SuperSlider, self).__init__()
 
@@ -61,7 +60,9 @@ class SuperSlider(QtWidgets.QWidget):
         # Create controls
         self.slider = QtWidgets.QSlider(QtCore.Qt.Orientation.Horizontal, self)
         self.slider.setFocusPolicy(QtCore.Qt.FocusPolicy.NoFocus)
-        self.slider.setRange(int(self.min * self.slider_scaling), int(self.max * self.slider_scaling))
+        self.slider.setRange(
+            int(self.min * self.slider_scaling), int(self.max * self.slider_scaling)
+        )
         self.slider.setValue(int(self.value * self.slider_scaling))
         self.slider.setTickInterval(self.slider_scaling)
         self.slider.setTickPosition(QtWidgets.QSlider.TickPosition.TicksBelow)

--- a/src/cfclient/utils/callbacks.py
+++ b/src/cfclient/utils/callbacks.py
@@ -1,0 +1,32 @@
+"""
+Simple callback utilities (previously provided by cflib).
+
+Caller is an observer-pattern helper: register callbacks with add_callback(),
+remove them with remove_callback(), and fire all registered callbacks by
+calling the Caller instance.
+"""
+
+
+class Caller:
+    """Container for managing and invoking a list of callbacks."""
+
+    def __init__(self):
+        self._callbacks = []
+
+    def add_callback(self, cb):
+        """Register a callback (ignored if already registered)."""
+        if cb not in self._callbacks:
+            self._callbacks.append(cb)
+
+    def remove_callback(self, cb):
+        """Remove a previously registered callback."""
+        self._callbacks.remove(cb)
+
+    def call(self, *args, **kwargs):
+        """Invoke all registered callbacks with the given arguments."""
+        copy = list(self._callbacks)
+        for cb in copy:
+            cb(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        self.call(*args, **kwargs)

--- a/src/cfclient/utils/callbacks.py
+++ b/src/cfclient/utils/callbacks.py
@@ -19,8 +19,11 @@ class Caller:
             self._callbacks.append(cb)
 
     def remove_callback(self, cb):
-        """Remove a previously registered callback."""
-        self._callbacks.remove(cb)
+        """Remove a previously registered callback (no-op if not registered)."""
+        try:
+            self._callbacks.remove(cb)
+        except ValueError:
+            pass
 
     def call(self, *args, **kwargs):
         """Invoke all registered callbacks with the given arguments."""

--- a/src/cfclient/utils/config_manager.py
+++ b/src/cfclient/utils/config_manager.py
@@ -38,18 +38,19 @@ import os
 import copy
 
 from .singleton import Singleton
-from cflib.utils.callbacks import Caller
+from cfclient.utils.callbacks import Caller
 
 import cfclient
 
-__author__ = 'Bitcraze AB/Allyn Bauer'
-__all__ = ['ConfigManager']
+__author__ = "Bitcraze AB/Allyn Bauer"
+__all__ = ["ConfigManager"]
 
 logger = logging.getLogger(__name__)
 
 
 class ConfigManager(metaclass=Singleton):
-    """ Singleton class for managing input processing """
+    """Singleton class for managing input processing"""
+
     conf_needs_reload = Caller()
     configs_dir = cfclient.config_path + "/input"
 
@@ -76,8 +77,10 @@ class ConfigManager(metaclass=Singleton):
     def get_list_of_configs(self):
         """Reload the configurations from file"""
         try:
-            configs = [os.path.basename(f) for f in
-                       glob.glob(self.configs_dir + "/[A-Za-z]*.json")]
+            configs = [
+                os.path.basename(f)
+                for f in glob.glob(self.configs_dir + "/[A-Za-z]*.json")
+            ]
             self._input_config = []
             self._input_settings = []
             self._list_of_configs = []
@@ -86,16 +89,17 @@ class ConfigManager(metaclass=Singleton):
                 json_data = open(self.configs_dir + "/%s" % conf)
                 data = json.load(json_data)
                 new_input_device = {}
-                new_input_settings = {"updateperiod": 10,
-                                      "springythrottle": True,
-                                      "rp_dead_band": 0.05}
+                new_input_settings = {
+                    "updateperiod": 10,
+                    "springythrottle": True,
+                    "rp_dead_band": 0.05,
+                }
                 for s in data["inputconfig"]["inputdevice"]:
                     if s == "axis":
                         for a in data["inputconfig"]["inputdevice"]["axis"]:
                             axis = {}
                             axis["scale"] = a["scale"]
-                            axis["offset"] = a[
-                                "offset"] if "offset" in a else 0.0
+                            axis["offset"] = a["offset"] if "offset" in a else 0.0
                             axis["type"] = a["type"]
                             axis["key"] = a["key"]
                             axis["name"] = a["name"]
@@ -110,15 +114,13 @@ class ConfigManager(metaclass=Singleton):
                                 locaxis = copy.deepcopy(axis)
                                 if "ids" in a:
                                     if id == a["ids"][0]:
-                                        locaxis["scale"] = locaxis[
-                                            "scale"] * -1
+                                        locaxis["scale"] = locaxis["scale"] * -1
                                 locaxis["id"] = id
                                 # 'type'-'id' defines unique index for axis
                                 index = "%s-%d" % (a["type"], id)
                                 new_input_device[index] = locaxis
                     else:
-                        new_input_settings[s] = data[
-                            "inputconfig"]["inputdevice"][s]
+                        new_input_settings[s] = data["inputconfig"]["inputdevice"][s]
                 self._input_config.append(new_input_device)
                 self._input_settings.append(new_input_settings)
                 json_data.close()
@@ -129,7 +131,7 @@ class ConfigManager(metaclass=Singleton):
 
     def save_config(self, input_map, config_name):
         """Save a configuration to file"""
-        mapping = {'inputconfig': {'inputdevice': {'axis': []}}}
+        mapping = {"inputconfig": {"inputdevice": {"axis": []}}}
 
         # Create intermediate structure for the configuration file
         funcs = {}
@@ -156,12 +158,12 @@ class ConfigManager(metaclass=Singleton):
             axis["type"] = func[0]["type"]
             mapping["inputconfig"]["inputdevice"]["axis"].append(axis)
 
-        mapping["inputconfig"]['inputdevice']['name'] = config_name
-        mapping["inputconfig"]['inputdevice']['updateperiod'] = 10
+        mapping["inputconfig"]["inputdevice"]["name"] = config_name
+        mapping["inputconfig"]["inputdevice"]["updateperiod"] = 10
 
         filename = ConfigManager().configs_dir + "/%s.json" % config_name
         logger.info("Saving config to [%s]", filename)
-        json_data = open(filename, 'w')
+        json_data = open(filename, "w")
         json_data.write(json.dumps(mapping, indent=2))
         json_data.close()
 
@@ -172,11 +174,11 @@ class ConfigManager(metaclass=Singleton):
 
         # The parameter that used to be called 'althold' has been renamed to
         # 'assistedControl'
-        althold = 'althold'
-        assistedControl = 'assistedControl'
+        althold = "althold"
+        assistedControl = "assistedControl"
 
-        if axis['key'] == althold:
-            axis['key'] = assistedControl
+        if axis["key"] == althold:
+            axis["key"] = assistedControl
 
-        if axis['name'] == althold:
-            axis['name'] = assistedControl
+        if axis["name"] == althold:
+            axis["name"] = assistedControl

--- a/src/cfclient/utils/input/__init__.py
+++ b/src/cfclient/utils/input/__init__.py
@@ -38,6 +38,7 @@ Windows drivers.
 The input device's axes and buttons are mapped to software inputs using a
 configuration file.
 """
+
 import os
 import re
 import glob
@@ -53,13 +54,13 @@ from cfclient.utils.config import Config
 from cfclient.utils.config_manager import ConfigManager
 
 from cfclient.utils.periodictimer import PeriodicTimer
-from cflib.utils.callbacks import Caller
+from cfclient.utils.callbacks import Caller
 from .mux.nomux import NoMux
 from .mux.takeovermux import TakeOverMux
 from .mux.takeoverselectivemux import TakeOverSelectiveMux
 
-__author__ = 'Bitcraze AB'
-__all__ = ['JoystickReader']
+__author__ = "Bitcraze AB"
+__all__ = ["JoystickReader"]
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +77,7 @@ class JoystickReader(object):
     Thread that will read input from devices/joysticks and send control-set
     points to the Crazyflie
     """
+
     inputConfig = []
 
     ASSISTED_CONTROL_ALTHOLD = 0
@@ -86,8 +88,7 @@ class JoystickReader(object):
     def __init__(self, do_device_discovery=True):
         self._input_device = None
 
-        self._mux = [NoMux(self), TakeOverSelectiveMux(self),
-                     TakeOverMux(self)]
+        self._mux = [NoMux(self), TakeOverSelectiveMux(self), TakeOverMux(self)]
         # Set NoMux as default
         self._selected_mux = self._mux[0]
 
@@ -136,10 +137,10 @@ class JoystickReader(object):
 
         self._dev_blacklist = None
         if len(Config().get("input_device_blacklist")) > 0:
-            self._dev_blacklist = re.compile(
-                Config().get("input_device_blacklist"))
-        logger.info("Using device blacklist [{}]".format(
-            Config().get("input_device_blacklist")))
+            self._dev_blacklist = re.compile(Config().get("input_device_blacklist"))
+        logger.info(
+            "Using device blacklist [{}]".format(Config().get("input_device_blacklist"))
+        )
 
         self._available_devices = {}
 
@@ -147,8 +148,7 @@ class JoystickReader(object):
         self._read_timer = PeriodicTimer(INPUT_READ_PERIOD, self.read_input)
 
         if do_device_discovery:
-            self._discovery_timer = PeriodicTimer(1.0,
-                                                  self._do_device_discovery)
+            self._discovery_timer = PeriodicTimer(1.0, self._do_device_discovery)
             self._discovery_timer.start()
 
         # Check if user config exists, otherwise copy files
@@ -156,10 +156,8 @@ class JoystickReader(object):
             logger.info("No user config found, copying dist files")
             os.makedirs(ConfigManager().configs_dir)
 
-        for f in glob.glob(
-                cfclient.module_path + "/configs/input/[A-Za-z]*.json"):
-            dest = os.path.join(ConfigManager().
-                                configs_dir, os.path.basename(f))
+        for f in glob.glob(cfclient.module_path + "/configs/input/[A-Za-z]*.json"):
+            dest = os.path.join(ConfigManager().configs_dir, os.path.basename(f))
             if not os.path.isfile(dest):
                 logger.debug("Copying %s", f)
                 shutil.copy2(f, ConfigManager().configs_dir)
@@ -239,9 +237,9 @@ class JoystickReader(object):
         approved_devs = []
 
         for dev in devs:
-            if ((not self._dev_blacklist) or
-                    (self._dev_blacklist and
-                     not self._dev_blacklist.match(dev.name))):
+            if (not self._dev_blacklist) or (
+                self._dev_blacklist and not self._dev_blacklist.match(dev.name)
+            ):
                 dev.input = self
                 approved_devs.append(dev)
 
@@ -282,9 +280,8 @@ class JoystickReader(object):
             self._input_device = None
 
     def read_raw_values(self):
-        """ Read raw values from the input device."""
-        [axes, buttons, mapped_values] = self._input_device.read(
-            include_raw=True)
+        """Read raw values from the input device."""
+        [axes, buttons, mapped_values] = self._input_device.read(include_raw=True)
         dict_axes = {}
         dict_buttons = {}
 
@@ -327,19 +324,19 @@ class JoystickReader(object):
             device = self._get_device_from_name(device_name)
             self._selected_mux.add_device(device, role)
             # Update the UI with the limiting for this device
-            self.limiting_updated.call(device.limit_rp,
-                                       device.limit_yaw,
-                                       device.limit_thrust)
+            self.limiting_updated.call(
+                device.limit_rp, device.limit_yaw, device.limit_thrust
+            )
             self._read_timer.start()
             return device.supports_mapping
         except Exception:
             self.device_error.call(
-                "Error while opening/initializing  input device\n\n%s" %
-                (traceback.format_exc()))
+                "Error while opening/initializing  input device\n\n%s"
+                % (traceback.format_exc())
+            )
 
         if not self._input_device:
-            self.device_error.call(
-                "Could not find device {}".format(device_name))
+            self.device_error.call("Could not find device {}".format(device_name))
         return False
 
     def resume_input(self):
@@ -368,12 +365,17 @@ class JoystickReader(object):
 
             if data:
                 if data.toggled.assistedControl:
-                    if self._assisted_control == \
-                            JoystickReader.ASSISTED_CONTROL_POSHOLD or \
-                            self._assisted_control == \
-                            JoystickReader.ASSISTED_CONTROL_HOVER:
-                        if data.assistedControl and self._assisted_control != \
-                                JoystickReader.ASSISTED_CONTROL_HOVER:
+                    if (
+                        self._assisted_control
+                        == JoystickReader.ASSISTED_CONTROL_POSHOLD
+                        or self._assisted_control
+                        == JoystickReader.ASSISTED_CONTROL_HOVER
+                    ):
+                        if (
+                            data.assistedControl
+                            and self._assisted_control
+                            != JoystickReader.ASSISTED_CONTROL_HOVER
+                        ):
                             for d in self._selected_mux.devices():
                                 d.limit_thrust = False
                                 d.limit_rp = False
@@ -385,71 +387,82 @@ class JoystickReader(object):
                             for d in self._selected_mux.devices():
                                 d.limit_thrust = True
                                 d.limit_rp = True
-                    if self._assisted_control == \
-                            JoystickReader.ASSISTED_CONTROL_ALTHOLD:
-                        self.assisted_control_updated.call(
-                                            data.assistedControl)
-                    if ((self._assisted_control ==
-                            JoystickReader.ASSISTED_CONTROL_HEIGHTHOLD) or
-                            (self._assisted_control ==
-                             JoystickReader.ASSISTED_CONTROL_HOVER)):
+                    if (
+                        self._assisted_control
+                        == JoystickReader.ASSISTED_CONTROL_ALTHOLD
+                    ):
+                        self.assisted_control_updated.call(data.assistedControl)
+                    if (
+                        self._assisted_control
+                        == JoystickReader.ASSISTED_CONTROL_HEIGHTHOLD
+                    ) or (
+                        self._assisted_control == JoystickReader.ASSISTED_CONTROL_HOVER
+                    ):
                         try:
-                            self.assisted_control_updated.call(
-                                                data.assistedControl)
+                            self.assisted_control_updated.call(data.assistedControl)
                             if not data.assistedControl:
                                 # Reset height controller state to initial
                                 # target height both in the UI and in the
                                 # Crazyflie.
                                 # TODO: Implement a proper state update of the
                                 #       input layer
-                                self.heighthold_input_updated.\
-                                    call(0, 0,
-                                         0, INITAL_TAGET_HEIGHT)
-                                self.hover_input_updated.\
-                                    call(0, 0,
-                                         0, INITAL_TAGET_HEIGHT)
+                                self.heighthold_input_updated.call(
+                                    0, 0, 0, INITAL_TAGET_HEIGHT
+                                )
+                                self.hover_input_updated.call(
+                                    0, 0, 0, INITAL_TAGET_HEIGHT
+                                )
                         except Exception as e:
                             logger.warning(
                                 "Exception while doing callback from "
                                 "input-device for assited "
-                                "control: {}".format(e))
+                                "control: {}".format(e)
+                            )
 
                 if data.toggled.estop:
                     try:
                         self.emergency_stop_updated.call(data.estop)
                     except Exception as e:
-                        logger.warning("Exception while doing callback from"
-                                       "input-device for estop: {}".format(e))
+                        logger.warning(
+                            "Exception while doing callback from"
+                            "input-device for estop: {}".format(e)
+                        )
                 if data.toggled.arm and data._prev_btn_values["arm"]:
                     try:
                         self.arm_updated.call(data.arm)
                     except Exception as e:
-                        logger.warning("Exception while doing callback from"
-                                       "input-device for arm: {}".format(e))
+                        logger.warning(
+                            "Exception while doing callback from"
+                            "input-device for arm: {}".format(e)
+                        )
                 if data.toggled.alt1:
                     try:
                         self.alt1_updated.call(data.alt1)
                     except Exception as e:
-                        logger.warning("Exception while doing callback from"
-                                       "input-device for alt1: {}".format(e))
+                        logger.warning(
+                            "Exception while doing callback from"
+                            "input-device for alt1: {}".format(e)
+                        )
                 if data.toggled.alt2:
                     try:
                         self.alt2_updated.call(data.alt2)
                     except Exception as e:
-                        logger.warning("Exception while doing callback from"
-                                       "input-device for alt2: {}".format(e))
+                        logger.warning(
+                            "Exception while doing callback from"
+                            "input-device for alt2: {}".format(e)
+                        )
 
                 # Reset height target when height-hold is not selected
-                if not data.assistedControl or \
-                        (self._assisted_control !=
-                         JoystickReader.ASSISTED_CONTROL_HEIGHTHOLD and
-                         self._assisted_control !=
-                         JoystickReader.ASSISTED_CONTROL_HOVER):
+                if not data.assistedControl or (
+                    self._assisted_control != JoystickReader.ASSISTED_CONTROL_HEIGHTHOLD
+                    and self._assisted_control != JoystickReader.ASSISTED_CONTROL_HOVER
+                ):
                     self._target_height = INITAL_TAGET_HEIGHT
 
-                if self._assisted_control == \
-                        JoystickReader.ASSISTED_CONTROL_POSHOLD \
-                        and data.assistedControl:
+                if (
+                    self._assisted_control == JoystickReader.ASSISTED_CONTROL_POSHOLD
+                    and data.assistedControl
+                ):
                     vx = data.roll
                     vy = data.pitch
                     vz = data.thrust
@@ -457,9 +470,10 @@ class JoystickReader(object):
                     # The odd use of vx and vy is to map forward on the
                     # physical joystick to positive X-axis
                     self.assisted_input_updated.call(vy, -vx, vz, yawrate)
-                elif self._assisted_control == \
-                        JoystickReader.ASSISTED_CONTROL_HOVER \
-                        and data.assistedControl:
+                elif (
+                    self._assisted_control == JoystickReader.ASSISTED_CONTROL_HOVER
+                    and data.assistedControl
+                ):
                     vx = data.roll
                     vy = data.pitch
 
@@ -476,27 +490,31 @@ class JoystickReader(object):
                     yawrate = -data.yaw
                     # The odd use of vx and vy is to map forward on the
                     # physical joystick to positive X-axis
-                    self.hover_input_updated.call(vy, -vx, yawrate,
-                                                  self._target_height)
+                    self.hover_input_updated.call(vy, -vx, yawrate, self._target_height)
                 else:
                     # Update the user roll/pitch trim from device
                     if data.toggled.pitchNeg and data.pitchNeg:
-                        self.trim_pitch -= .2
+                        self.trim_pitch -= 0.2
                     if data.toggled.pitchPos and data.pitchPos:
-                        self.trim_pitch += .2
+                        self.trim_pitch += 0.2
                     if data.toggled.rollNeg and data.rollNeg:
-                        self.trim_roll -= .2
+                        self.trim_roll -= 0.2
                     if data.toggled.rollPos and data.rollPos:
-                        self.trim_roll += .2
+                        self.trim_roll += 0.2
 
-                    if data.toggled.pitchNeg or data.toggled.pitchPos or \
-                            data.toggled.rollNeg or data.toggled.rollPos:
-                        self.rp_trim_updated.call(self.trim_roll,
-                                                  self.trim_pitch)
+                    if (
+                        data.toggled.pitchNeg
+                        or data.toggled.pitchPos
+                        or data.toggled.rollNeg
+                        or data.toggled.rollPos
+                    ):
+                        self.rp_trim_updated.call(self.trim_roll, self.trim_pitch)
 
-                    if self._assisted_control == \
-                            JoystickReader.ASSISTED_CONTROL_HEIGHTHOLD \
-                            and data.assistedControl:
+                    if (
+                        self._assisted_control
+                        == JoystickReader.ASSISTED_CONTROL_HEIGHTHOLD
+                        and data.assistedControl
+                    ):
                         roll = data.roll + self.trim_roll
                         pitch = data.pitch + self.trim_pitch
                         yawrate = -data.yaw
@@ -509,9 +527,9 @@ class JoystickReader(object):
                             self._target_height = self._hover_max_height
                         if self._target_height < MIN_TARGET_HEIGHT:
                             self._target_height = MIN_TARGET_HEIGHT
-                        self.heighthold_input_updated.call(roll, -pitch,
-                                                           yawrate,
-                                                           self._target_height)
+                        self.heighthold_input_updated.call(
+                            roll, -pitch, yawrate, self._target_height
+                        )
                     else:
                         # Using alt hold the data is not in a percentage
                         if not data.assistedControl:
@@ -524,16 +542,21 @@ class JoystickReader(object):
                         if data.thrust > 0xFFFF:
                             data.thrust = 0xFFFF
 
-                        self.input_updated.call(data.roll + self.trim_roll,
-                                                data.pitch + self.trim_pitch,
-                                                data.yaw, data.thrust)
+                        self.input_updated.call(
+                            data.roll + self.trim_roll,
+                            data.pitch + self.trim_pitch,
+                            data.yaw,
+                            data.thrust,
+                        )
             else:
                 self.input_updated.call(0, 0, 0, 0)
         except Exception:
-            logger.warning("Exception while reading inputdevice: %s",
-                           traceback.format_exc())
-            self.device_error.call("Error reading from input device\n\n%s" %
-                                   traceback.format_exc())
+            logger.warning(
+                "Exception while reading inputdevice: %s", traceback.format_exc()
+            )
+            self.device_error.call(
+                "Error reading from input device\n\n%s" % traceback.format_exc()
+            )
             self.input_updated.call(0, 0, 0, 0)
             self._read_timer.stop()
 

--- a/src/cfclient/utils/input/__init__.py
+++ b/src/cfclient/utils/input/__init__.py
@@ -415,7 +415,7 @@ class JoystickReader(object):
                         except Exception as e:
                             logger.warning(
                                 "Exception while doing callback from "
-                                "input-device for assited "
+                                "input-device for assisted "
                                 "control: {}".format(e)
                             )
 

--- a/src/cfclient/utils/periodictimer.py
+++ b/src/cfclient/utils/periodictimer.py
@@ -32,11 +32,11 @@ the timer expires once started.
 
 import logging
 from threading import Thread
-from cflib.utils.callbacks import Caller
+from cfclient.utils.callbacks import Caller
 import time
 
-__author__ = 'Bitcraze AB'
-__all__ = ['PeriodicTimer']
+__author__ = "Bitcraze AB"
+__all__ = ["PeriodicTimer"]
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +68,6 @@ class PeriodicTimer:
 
 
 class _PeriodicTimerThread(Thread):
-
     def __init__(self, period, caller):
         super(_PeriodicTimerThread, self).__init__()
         self._period = period


### PR DESCRIPTION
This PR ports the flight tab and other necessary bits to use cflib2. This includes: 

- Replacing synchronous LogConfig/callback patterns with cflib2 async log streams for motor telemetry (FlightTab), battery monitoring (MainUI), and pose logging (PoseLogger)
- Moving commander setpoint dispatch from inline lambdas to explicit async methods in MainUI, using `run_coroutine_threadsafe` to bridge the joystick reader thread to the async event loop
- Porting FlightTab's param reads (deck detection, sensor availability, supervisor info) to cflib2's async param API via a `_setup_after_connect` coroutine
- Porting high-level commander actions (take off, land, directional moves) and emergency stop/arming to async
- Decoupling PoseLogger from Crazyflie lifecycle — it now uses explicit `start(cf)`/`stop()` instead of self-registering on connection callbacks
- Introducing `cfclient.utils.callbacks.Caller` to replace `cflib.utils.callbacks.Caller`
- Adding `inputDeviceReader` to PluginHelper as a proper instance attribute
- Guarding all FlightTab accesses to `inputDeviceReader` and `pose_logger` for None safety