### PR TITLE
Re-enable gamepad input device menu and fix commander thread safety

### DIFF
--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -38,8 +38,10 @@ from cfclient.ui.tab_toolbox import TabToolbox
 import cfclient.ui.tabs
 from cfclient.ui.connectivity_manager import ConnectivityManager
 from cfclient.utils.config import Config
+from cfclient.utils.config_manager import ConfigManager
 from cfclient.utils.input import JoystickReader
 from cfclient.utils.ui import UiUtils
+from cfclient.ui.dialogs.inputconfigdialogue import InputConfigDialogue
 from cflib2 import Crazyflie, LinkContext
 from cflib2.error import DisconnectedError
 from cflib2.toc_cache import FileTocCache
@@ -57,6 +59,7 @@ from PySide6.QtGui import QShortcut
 from PySide6.QtGui import QCloseEvent
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtGui import QResizeEvent
+from PySide6.QtWidgets import QLabel
 from PySide6.QtWidgets import QMenu
 from PySide6.QtWidgets import QMessageBox
 
@@ -79,6 +82,8 @@ class BatteryStates:
 
 class MainUI(QtWidgets.QMainWindow, main_window_class):
     _battery_signal = Signal(float, int)
+    _input_device_error_signal = Signal(str)
+    _input_discovery_signal = Signal(object)
 
     def __init__(self, *args: object) -> None:
         super(MainUI, self).__init__(*args)
@@ -113,9 +118,11 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self.menuItemAbout.setEnabled(False)
         self.menuItemBootloader.setEnabled(False)
         self._menu_cf2_config.setEnabled(False)
-        self.menuItemConfInputDevice.setEnabled(False)
         self.logConfigAction.setEnabled(False)
-        self._menu_inputdevice.setEnabled(False)
+
+        self.menuItemConfInputDevice.triggered.connect(
+            self._show_input_device_config_dialog
+        )
 
         # Emergency stop button
         self.esButton.setEnabled(False)
@@ -141,6 +148,10 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
         # Input device reader (joystick)
         self._joystick_reader = JoystickReader()
+        self._active_device = ""
+
+        self._statusbar_label = QLabel("No input-device found, insert one to fly.")
+        self.statusBar().addWidget(self._statusbar_label)
 
         # Connect joystick input to Crazyflie commander
         self._joystick_reader.input_updated.add_callback(self._send_setpoint)
@@ -151,6 +162,16 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self._send_zdistance
         )
         self._joystick_reader.hover_input_updated.add_callback(self._send_hover)
+
+        # Input device error and discovery signals
+        self._input_device_error_signal.connect(self._display_input_device_error)
+        self._joystick_reader.device_error.add_callback(
+            self._input_device_error_signal.emit
+        )
+        self._input_discovery_signal.connect(self.device_discovery)
+        self._joystick_reader.device_discovery.add_callback(
+            self._input_discovery_signal.emit
+        )
 
         # pluginhelper for tabs
         self._pose_logger = PoseLogger()
@@ -178,6 +199,33 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             self.tabs_menu_item, self.toolboxes_menu_item, self.tab_widget
         )
         self.read_tab_toolbox_config(self.loaded_tab_toolboxes)
+
+        # Input device mux menu
+        self._all_role_menus = ()
+        self._available_devices = ()
+        self._all_mux_nodes = ()
+
+        self._mux_group = QActionGroup(self._menu_inputdevice)
+        self._mux_group.setExclusive(True)
+        for m in self._joystick_reader.available_mux():
+            node = QAction(
+                m.name, self._menu_inputdevice, checkable=True, enabled=False
+            )
+            node.toggled.connect(self._mux_selected)
+            self._mux_group.addAction(node)
+            self._menu_inputdevice.addAction(node)
+            self._all_mux_nodes += (node,)
+            mux_subnodes = ()
+            for name in m.supported_roles():
+                sub_node = QMenu(
+                    "    {}".format(name), self._menu_inputdevice, enabled=False
+                )
+                self._menu_inputdevice.addMenu(sub_node)
+                mux_subnodes += (sub_node,)
+                self._all_role_menus += ({"muxmenu": node, "rolemenu": sub_node},)
+            node.setData((m, mux_subnodes))
+
+        self._mapping_support = True
 
         # Theme selection
         self._theme_group = QActionGroup(self.menuThemes)
@@ -311,9 +359,9 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
     # --- Commander pipeline ---
 
-    async def _safe_send(self, coro):
+    async def _safe_send(self, coro_fn):
         try:
-            await coro
+            await coro_fn()
         except DisconnectedError:
             pass
 
@@ -332,7 +380,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             return
         future = asyncio.run_coroutine_threadsafe(
             self._safe_send(
-                cf.commander().send_setpoint_rpyt(roll, pitch, yaw, int(thrust))
+                lambda: cf.commander().send_setpoint_rpyt(roll, pitch, yaw, int(thrust))
             ),
             self._loop,
         )
@@ -344,7 +392,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             return
         future = asyncio.run_coroutine_threadsafe(
             self._safe_send(
-                cf.commander().send_setpoint_velocity_world(vx, vy, vz, yawrate)
+                lambda: cf.commander().send_setpoint_velocity_world(vx, vy, vz, yawrate)
             ),
             self._loop,
         )
@@ -356,7 +404,9 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             return
         future = asyncio.run_coroutine_threadsafe(
             self._safe_send(
-                cf.commander().send_setpoint_zdistance(roll, pitch, yawrate, zdistance)
+                lambda: cf.commander().send_setpoint_zdistance(
+                    roll, pitch, yawrate, zdistance
+                )
             ),
             self._loop,
         )
@@ -368,7 +418,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             return
         future = asyncio.run_coroutine_threadsafe(
             self._safe_send(
-                cf.commander().send_setpoint_hover(vx, vy, yawrate, zdistance)
+                lambda: cf.commander().send_setpoint_hover(vx, vy, yawrate, zdistance)
             ),
             self._loop,
         )
@@ -627,6 +677,163 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         except KeyError:
             theme = "Default"
         self._check_theme(theme)
+
+    # --- Input device menu ---
+
+    def _show_input_device_config_dialog(self):
+        self.inputConfig = InputConfigDialogue(self._joystick_reader)
+        self.inputConfig.show()
+
+    def _display_input_device_error(self, error):
+        if self.cf is not None:
+            create_task(self._async_disconnect())
+        QMessageBox.critical(self, "Input device error", error)
+
+    def _mux_selected(self, checked):
+        if not checked:
+            (mux, sub_nodes) = self.sender().data()
+            for s in sub_nodes:
+                s.setEnabled(False)
+        else:
+            (mux, sub_nodes) = self.sender().data()
+            for s in sub_nodes:
+                s.setEnabled(True)
+            self._joystick_reader.set_mux(mux=mux)
+
+            # Go though the tree and select devices/mapping that was
+            # selected before it was disabled.
+            for role_node in sub_nodes:
+                for dev_node in role_node.children():
+                    if type(dev_node) is QAction and dev_node.isChecked():
+                        dev_node.toggled.emit(True)
+
+            self._update_input_device_footer()
+
+    def _get_dev_status(self, device):
+        msg = "{}".format(device.name)
+        if device.supports_mapping:
+            map_name = "No input mapping"
+            if device.input_map:
+                map_name = device.input_map_name
+            msg += " ({})".format(map_name)
+        return msg
+
+    def _update_input_device_footer(self):
+        msg = ""
+
+        if len(self._joystick_reader.available_devices()) > 0:
+            mux = self._joystick_reader._selected_mux
+            msg = "Using {} mux with ".format(mux.name)
+            for key in list(mux._devs.keys())[:-1]:
+                if mux._devs[key]:
+                    msg += "{}, ".format(self._get_dev_status(mux._devs[key]))
+                else:
+                    msg += "N/A, "
+            key = list(mux._devs.keys())[-1]
+            if mux._devs[key]:
+                msg += "{}".format(self._get_dev_status(mux._devs[key]))
+            else:
+                msg += "N/A"
+        else:
+            msg = "No input device found"
+        self._statusbar_label.setText(msg)
+
+    def _inputdevice_selected(self, checked):
+        (map_menu, device, mux_menu) = self.sender().data()
+        if not checked:
+            if map_menu:
+                map_menu.setEnabled(False)
+        else:
+            if map_menu:
+                map_menu.setEnabled(True)
+
+            (mux, sub_nodes) = mux_menu.data()
+            for role_node in sub_nodes:
+                for dev_node in role_node.children():
+                    if type(dev_node) is QAction and dev_node.isChecked():
+                        if (
+                            device.id == dev_node.data()[1].id
+                            and dev_node is not self.sender()
+                        ):
+                            dev_node.setChecked(False)
+
+            role_in_mux = str(self.sender().parent().title()).strip()
+            logger.info("Role of {} is {}".format(device.name, role_in_mux))
+
+            Config().set("input_device", str(device.name))
+
+            self._mapping_support = self._joystick_reader.start_input(
+                device.name, role_in_mux
+            )
+        self._update_input_device_footer()
+
+    def _inputconfig_selected(self, checked):
+        if not checked:
+            return
+
+        selected_mapping = str(self.sender().text())
+        device = self.sender().data().data()[1]
+        self._joystick_reader.set_input_map(device.name, selected_mapping)
+        self._update_input_device_footer()
+
+    def device_discovery(self, devs):
+        """Called when new devices have been added"""
+        for menu in self._all_role_menus:
+            role_menu = menu["rolemenu"]
+            mux_menu = menu["muxmenu"]
+            dev_group = QActionGroup(role_menu)
+            dev_group.setExclusive(True)
+            for d in devs:
+                dev_node = QAction(d.name, role_menu, checkable=True, enabled=True)
+                role_menu.addAction(dev_node)
+                dev_group.addAction(dev_node)
+                dev_node.toggled.connect(self._inputdevice_selected)
+
+                map_node = None
+                if d.supports_mapping:
+                    map_node = QMenu("    Input map", role_menu, enabled=False)
+                    map_group = QActionGroup(role_menu)
+                    map_group.setExclusive(True)
+                    dev_node.setData((map_node, d))
+                    for c in ConfigManager().get_list_of_configs():
+                        node = QAction(c, map_node, checkable=True, enabled=True)
+                        node.toggled.connect(self._inputconfig_selected)
+                        map_node.addAction(node)
+                        node.setData(dev_node)
+                        map_group.addAction(node)
+                        if d not in self._available_devices:
+                            last_map = Config().get("device_config_mapping")
+                            if d.name in last_map and last_map[d.name] == c:
+                                node.setChecked(True)
+                    role_menu.addMenu(map_node)
+                dev_node.setData((map_node, d, mux_menu))
+
+        # Update the list of what devices we found
+        self._available_devices = ()
+        for d in devs:
+            self._available_devices += (d,)
+
+        # Only enable MUX nodes if we have enough devices to cover
+        # the roles
+        for mux_node in self._all_mux_nodes:
+            (mux, sub_nodes) = mux_node.data()
+            if len(mux.supported_roles()) <= len(self._available_devices):
+                mux_node.setEnabled(True)
+
+        # Select default mux
+        if self._all_mux_nodes[0].isEnabled():
+            self._all_mux_nodes[0].setChecked(True)
+
+        # Select previously used device or first available
+        if Config().get("input_device") in [d.name for d in devs]:
+            for dev_menu in self._all_role_menus[0]["rolemenu"].actions():
+                if dev_menu.text() == Config().get("input_device"):
+                    dev_menu.setChecked(True)
+        else:
+            self._all_role_menus[0]["rolemenu"].actions()[0].setChecked(True)
+            logger.info("Select first device")
+
+        self._update_input_device_footer()
 
     # --- Window events ---
 


### PR DESCRIPTION
Restore the input device menu system that was disabled during the cflib2 migration. The menu code (mux selection, device discovery, mapping configuration, status bar) has no cflib dependency and was removed unnecessarily.

Also fix a RuntimeError ("no running event loop") in the commander pipeline by deferring coroutine creation to the event loop thread via lambdas, since the input reader calls from a background thread.