### PR TITLE
Handle exceptions for parameter values/types

### DIFF
--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -418,6 +418,7 @@ class ParamTab(TabToolbox, param_tab_class):
                 numeric_value = float(value)
             except ValueError:
                 logger.warning("Invalid parameter value: %s", value)
+                self.currentValue.setStyleSheet("border: 1px solid red")
                 return
         param = self._cf.param()
         try:

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -428,6 +428,10 @@ class ParamTab(TabToolbox, param_tab_class):
             logger.warning("Value out of range for parameter %s: %s", name, value)
             self.currentValue.setStyleSheet("border: 1px solid red")
             return
+        except TypeError:
+            logger.warning("Value has wrong type for parameter %s: %s", name, value)
+            self.currentValue.setStyleSheet("border: 1px solid red")
+            return
         # Read back updated value
         new_value = await param.get(name)
         self._update_node_value(name, new_value)


### PR DESCRIPTION
Handle TypeError for parameter value types in ParamTab and highlight invalid parameter values with a red border in ParamTab, following pattern of #794