### PR TITLE
eglSwapBuffers vispy warning

### DIFF
--- a/src/cfclient/ui/tabs/lighthouse_tab.py
+++ b/src/cfclient/ui/tabs/lighthouse_tab.py
@@ -157,7 +157,10 @@ class Plot3dLighthouse(scene.SceneCanvas):
     TEXT_OFFSET = np.array((0.0, 0, 0.25))
 
     def __init__(self):
-        scene.SceneCanvas.__init__(self, keys=None)
+        # Note: autoswap is disabled since Qt's QOpenGLWidget path already presents
+        # the FBO; enabling vispy autoswap here would cause a redundant swap and
+        # eglSwapBuffers warnings.
+        scene.SceneCanvas.__init__(self, keys=None, autoswap=False)
         self.unfreeze()
 
         self._view = self.central_widget.add_view()


### PR DESCRIPTION
When opening the Lighthouse tab, we repeatedly get this warning:
```
WARNING: eglSwapBuffers failed with 0x300d, surface: 0x0
WARNING:vispy:eglSwapBuffers failed with 0x300d, surface: 0x0
```

This is caused by Qt and vispy trying to do the same job. 

Specifically, vispy draws the 3D scene into an offscreen buffer (FBO), not directly onto the screen.

 Qt has a built-in mechanism where after vispy finishes drawing into the FBO, Qt takes that image and puts it on screen by itself.

Then, vispy, by default, also tries to put the scene on screen itself after every draw. That's caused by the `autoswap=True` default. But since Qt is already doing it, vispy's attempt is redundant and that's where we get the `0x300d` error.