### PR TITLE
Enforce type annotations and fix type errors across major tabs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
 ]
 
 [tool.ruff.lint]
-select = ["ANN"]
+extend-select = ["ANN"]
 
 [project.scripts]
 cfclient = "cfclient.gui:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ classifiers = [
 requires-python = ">= 3.11"
 
 dependencies = [
-        "cflib2 @ git+https://github.com/bitcraze/cflib2@526d0abdb3cc441a9f3716e15dee340b65d332d4",
+        "cflib2 @ git+https://github.com/bitcraze/cflib2@43dc1aec418a1739721fdd2957212ff24bd34e33",
         "setuptools",
         "appdirs~=1.4.0",
         "pyzmq~=26.0",
@@ -65,6 +65,9 @@ dev = [
     "pre-commit>=4.3.0",
     "ty>=0.0.18",
 ]
+
+[tool.ruff.lint]
+select = ["ANN"]
 
 [project.scripts]
 cfclient = "cfclient.gui:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ dev = [
 ]
 
 [tool.ruff.lint]
+# Enforce type annotations in addition to the default rule set
 extend-select = ["ANN"]
 
 [project.scripts]

--- a/src/cfclient/gui.py
+++ b/src/cfclient/gui.py
@@ -36,7 +36,9 @@ from typing import Literal
 import asyncio
 import logging
 
-from cflib2 import DisconnectedError
+from collections.abc import Coroutine
+
+from cflib2.error import DisconnectedError
 import PySide6.QtAsyncio as QtAsyncio
 
 
@@ -61,7 +63,7 @@ class Args:
     """Check python imports and exit successfully (intended for CI)"""
 
 
-def _task_done_callback(task):
+def _task_done_callback(task: asyncio.Task[object]) -> None:
     if task.cancelled():
         return
     try:
@@ -75,7 +77,7 @@ def _task_done_callback(task):
         os._exit(1)
 
 
-def create_task(coro):
+def create_task(coro: Coroutine[object, object, object]) -> asyncio.Task[object]:
     """Schedule a coroutine as a task with automatic exception logging.
 
     Use this instead of asyncio.ensure_future() to ensure exceptions
@@ -87,7 +89,7 @@ def create_task(coro):
     return task
 
 
-def main():
+def main() -> None:
     """
     Check starting conditions and start GUI.
 

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -38,7 +38,9 @@ import cfclient.ui.tabs
 from cfclient.ui.connectivity_manager import ConnectivityManager
 from cfclient.utils.config import Config
 from cfclient.utils.ui import UiUtils
-from cflib2 import Crazyflie, DisconnectedError, LinkContext, FileTocCache
+from cflib2 import Crazyflie, LinkContext
+from cflib2.error import DisconnectedError
+from cflib2.toc_cache import FileTocCache
 from PySide6 import QtWidgets
 from PySide6.QtUiTools import loadUiType
 from PySide6.QtCore import Slot
@@ -49,7 +51,9 @@ from PySide6.QtCore import QTimer
 from PySide6.QtGui import QAction
 from PySide6.QtGui import QActionGroup
 from PySide6.QtGui import QShortcut
+from PySide6.QtGui import QCloseEvent
 from PySide6.QtGui import QDesktopServices
+from PySide6.QtGui import QResizeEvent
 from PySide6.QtWidgets import QMenu
 from PySide6.QtWidgets import QMessageBox
 
@@ -67,7 +71,7 @@ UIState = ConnectivityManager.UIState
 
 
 class MainUI(QtWidgets.QMainWindow, main_window_class):
-    def __init__(self, *args):
+    def __init__(self, *args: object) -> None:
         super(MainUI, self).__init__(*args)
         self.setupUi(self)
 
@@ -157,7 +161,12 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
     # --- Tabs/toolboxes ---
 
-    def create_tab_toolboxes(self, tabs_menu_item, toolboxes_menu_item, tab_widget):
+    def create_tab_toolboxes(
+        self,
+        tabs_menu_item: QMenu,
+        toolboxes_menu_item: QMenu,
+        tab_widget: QtWidgets.QTabWidget,
+    ) -> dict[str, TabToolbox]:
         loaded_tab_toolboxes = {}
 
         for tab_class in cfclient.ui.tabs.available:
@@ -190,7 +199,9 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
         return loaded_tab_toolboxes
 
-    def read_tab_toolbox_config(self, loaded_tab_toolboxes):
+    def read_tab_toolbox_config(
+        self, loaded_tab_toolboxes: dict[str, TabToolbox]
+    ) -> None:
         for name in TabToolbox.read_open_tab_config():
             if name in loaded_tab_toolboxes.keys():
                 self._tab_toolbox_show_as_tab(loaded_tab_toolboxes[name])
@@ -199,19 +210,19 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
             if name in loaded_tab_toolboxes.keys():
                 self._tab_toolbox_show_as_toolbox(loaded_tab_toolboxes[name])
 
-    def toggle_tab_visibility(self, checked, tab_toolbox):
+    def toggle_tab_visibility(self, checked: bool, tab_toolbox: TabToolbox) -> None:
         if checked:
             self._tab_toolbox_show_as_tab(tab_toolbox)
         else:
             self._tab_toolbox_hide(tab_toolbox)
 
-    def toggle_toolbox_visibility(self, checked, tab_toolbox):
+    def toggle_toolbox_visibility(self, checked: bool, tab_toolbox: TabToolbox) -> None:
         if checked:
             self._tab_toolbox_show_as_toolbox(tab_toolbox)
         else:
             self._tab_toolbox_hide(tab_toolbox)
 
-    def _tab_toolbox_show_as_tab(self, tab_toolbox):
+    def _tab_toolbox_show_as_tab(self, tab_toolbox: TabToolbox) -> None:
         if tab_toolbox.get_display_state() == TabToolbox.DS_TOOLBOX:
             dock_widget = tab_toolbox.dock_widget
             self.removeDockWidget(dock_widget)
@@ -225,7 +236,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         tab_toolbox.toolbox_action_item.setChecked(False)
         tab_toolbox.set_display_state(TabToolbox.DS_TAB)
 
-    def _tab_toolbox_show_as_toolbox(self, tab_toolbox):
+    def _tab_toolbox_show_as_toolbox(self, tab_toolbox: TabToolbox) -> None:
         dock_widget = tab_toolbox.dock_widget
 
         if tab_toolbox.get_display_state() == TabToolbox.DS_TAB:
@@ -240,7 +251,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         tab_toolbox.toolbox_action_item.setChecked(True)
         tab_toolbox.set_display_state(TabToolbox.DS_TOOLBOX)
 
-    def _tab_toolbox_hide(self, tab_toolbox):
+    def _tab_toolbox_hide(self, tab_toolbox: TabToolbox) -> None:
         dock_widget = tab_toolbox.dock_widget
 
         if tab_toolbox.get_display_state() == TabToolbox.DS_TAB:
@@ -255,12 +266,14 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         tab_toolbox.set_display_state(TabToolbox.DS_HIDDEN)
 
     @Slot(Qt.DockWidgetArea)
-    def set_preferred_dock_area(self, area, tab_toolbox):
+    def set_preferred_dock_area(
+        self, area: Qt.DockWidgetArea, tab_toolbox: TabToolbox
+    ) -> None:
         tab_toolbox.set_preferred_dock_area(area)
 
     # --- Address ---
 
-    def _set_address(self):
+    def _set_address(self) -> None:
         address = 0xE7E7E7E7E7
         try:
             link_uri = Config().get("link_uri")
@@ -277,10 +290,10 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
     # --- Scanning ---
 
-    def _scan(self, address):
+    def _scan(self, address: int) -> None:
         create_task(self._async_scan(address))
 
-    async def _async_scan(self, address):
+    async def _async_scan(self, address: int) -> None:
         self.uiState = UIState.SCANNING
         self._update_ui_state()
 
@@ -290,7 +303,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
         self._interfaces_found(interfaces)
 
-    def _interfaces_found(self, interfaces):
+    def _interfaces_found(self, interfaces: list[tuple[str, str]]) -> None:
         selected_interface = self._connectivity_manager.get_interface()
 
         formatted_interfaces = []
@@ -326,7 +339,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
     # --- Connect / Disconnect ---
 
-    def _connect(self):
+    def _connect(self) -> None:
         if self.uiState == UIState.CONNECTED:
             create_task(self._async_disconnect())
         elif self.uiState == UIState.CONNECTING:
@@ -340,7 +353,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
                 uri = uri.split(" - ")[0]
             self._connect_task = create_task(self._async_connect(uri))
 
-    async def _async_connect(self, uri):
+    async def _async_connect(self, uri: str) -> None:
         self.uiState = UIState.CONNECTING
         self._update_ui_state()
 
@@ -368,7 +381,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         finally:
             self._connect_task = None
 
-    async def _watch_disconnect(self):
+    async def _watch_disconnect(self) -> None:
         try:
             reason = await self.cf.wait_disconnect()
             uri = self.cf.uri
@@ -383,7 +396,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         except asyncio.CancelledError:
             pass
 
-    async def _async_disconnect(self):
+    async def _async_disconnect(self) -> None:
         if self._disconnect_watch_task is not None:
             self._disconnect_watch_task.cancel()
             self._disconnect_watch_task = None
@@ -394,17 +407,17 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
         self.uiState = UIState.DISCONNECTED
         self._update_ui_state()
 
-    def _notify_tabs_connected(self):
+    def _notify_tabs_connected(self) -> None:
         for tab_toolbox in self.loaded_tab_toolboxes.values():
             tab_toolbox.connected(self.cf)
 
-    def _notify_tabs_disconnected(self):
+    def _notify_tabs_disconnected(self) -> None:
         for tab_toolbox in self.loaded_tab_toolboxes.values():
             tab_toolbox.disconnected()
 
     # --- UI state ---
 
-    def _update_ui_state(self):
+    def _update_ui_state(self) -> None:
         if self.uiState == UIState.DISCONNECTED:
             self.setWindowTitle("Not connected")
             canConnect = self._connectivity_manager.get_interface() is not None
@@ -436,7 +449,7 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
     # --- Theme ---
 
-    def _theme_selected(self, *args):
+    def _theme_selected(self, *args: object) -> None:
         for checkbox in self._theme_checkboxes:
             if checkbox.isChecked():
                 theme = checkbox.objectName()
@@ -444,13 +457,13 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
                 app.setStyleSheet(UiUtils.select_theme(theme))
                 Config().set("theme", theme)
 
-    def _check_theme(self, theme_name):
+    def _check_theme(self, theme_name: str) -> None:
         for theme in self._theme_checkboxes:
             if theme.objectName() == theme_name:
                 theme.setChecked(True)
                 self._theme_selected(True)
 
-    def set_default_theme(self):
+    def set_default_theme(self) -> None:
         try:
             theme = Config().get("theme")
         except KeyError:
@@ -459,22 +472,22 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
 
     # --- Window events ---
 
-    def closeEvent(self, event):
+    def closeEvent(self, event: QCloseEvent) -> None:
         Config().save_file()
         if self.cf is not None:
             create_task(self._async_disconnect())
         self.hide()
 
-    def resizeEvent(self, event):
+    def resizeEvent(self, event: QResizeEvent) -> None:
         Config().set("window_size", [event.size().width(), event.size().height()])
 
     # --- Misc ---
 
-    def _open_config_folder(self):
+    def _open_config_folder(self) -> None:
         QDesktopServices.openUrl(
             QUrl("file:///" + QDir.toNativeSeparators(cfclient.config_path))
         )
 
-    def closeAppRequest(self):
+    def closeAppRequest(self) -> None:
         self.close()
         sys.exit(0)

--- a/src/cfclient/ui/tab_toolbox.py
+++ b/src/cfclient/ui/tab_toolbox.py
@@ -38,6 +38,8 @@ from PySide6.QtGui import QCloseEvent
 
 from cfclient.utils.config import Config
 
+from cflib2 import Crazyflie
+
 __author__ = "Bitcraze AB"
 __all__ = ["TabToolbox"]
 
@@ -56,7 +58,7 @@ class TabToolbox(QtWidgets.QWidget):
     DS_TAB = 1
     DS_TOOLBOX = 2
 
-    def __init__(self, helper, tab_toolbox_name):
+    def __init__(self, helper: object, tab_toolbox_name: str) -> None:
         super(TabToolbox, self).__init__()
         self._helper = helper
         self.tab_toolbox_name = tab_toolbox_name
@@ -77,17 +79,17 @@ class TabToolbox(QtWidgets.QWidget):
         if self._dock_area == Qt.DockWidgetArea.NoDockWidgetArea:
             self._dock_area = Qt.DockWidgetArea.RightDockWidgetArea
 
-    def get_tab_toolbox_name(self):
+    def get_tab_toolbox_name(self) -> str:
         """Return the name that will be shown in the tab or toolbox"""
         return self.tab_toolbox_name
 
-    def is_visible(self):
+    def is_visible(self) -> bool:
         return self._display_state != self.DS_HIDDEN
 
-    def get_display_state(self):
+    def get_display_state(self) -> int:
         return self._display_state
 
-    def set_display_state(self, new_display_state):
+    def set_display_state(self, new_display_state: int) -> None:
         if new_display_state != self._display_state:
             self._display_state = new_display_state
             self._update_open_config(new_display_state)
@@ -97,37 +99,37 @@ class TabToolbox(QtWidgets.QWidget):
             else:
                 self.enable()
 
-    def preferred_dock_area(self):
+    def preferred_dock_area(self) -> Qt.DockWidgetArea:
         return self._dock_area
 
-    def set_preferred_dock_area(self, area):
+    def set_preferred_dock_area(self, area: Qt.DockWidgetArea) -> None:
         self._dock_area = area
         self._store_toolbox_area_config(area)
 
-    def connected(self, cf):
+    def connected(self, cf: Crazyflie) -> None:
         """Called when a Crazyflie is connected. Override in subclasses."""
         pass
 
-    def disconnected(self):
+    def disconnected(self) -> None:
         """Called when the Crazyflie is disconnected. Override in subclasses."""
         pass
 
-    def enable(self):
+    def enable(self) -> None:
         pass
 
-    def disable(self):
+    def disable(self) -> None:
         pass
 
     @classmethod
-    def read_open_tab_config(cls):
+    def read_open_tab_config(cls) -> list[str]:
         return cls._read_open_config(TabToolbox.CONF_KEY_OPEN_TABS)
 
     @classmethod
-    def read_open_toolbox_config(cls):
+    def read_open_toolbox_config(cls) -> list[str]:
         return TabToolbox._read_open_config(TabToolbox.CONF_KEY_OPEN_TOOLBOXES)
 
     @classmethod
-    def _read_open_config(cls, key):
+    def _read_open_config(cls, key: str) -> list[str]:
         config = []
         try:
             value = Config().get(key)
@@ -138,7 +140,7 @@ class TabToolbox(QtWidgets.QWidget):
 
         return config
 
-    def _update_open_config(self, display_state):
+    def _update_open_config(self, display_state: int) -> None:
         if display_state == self.DS_HIDDEN:
             self._remove_from_open_config(TabToolbox.CONF_KEY_OPEN_TABS)
             self._remove_from_open_config(TabToolbox.CONF_KEY_OPEN_TOOLBOXES)
@@ -149,7 +151,7 @@ class TabToolbox(QtWidgets.QWidget):
             self._remove_from_open_config(TabToolbox.CONF_KEY_OPEN_TABS)
             self._add_to_open_config(TabToolbox.CONF_KEY_OPEN_TOOLBOXES)
 
-    def _add_to_open_config(self, key):
+    def _add_to_open_config(self, key: str) -> None:
         config = self._read_open_config(key)
         name = self.tab_toolbox_name
 
@@ -157,7 +159,7 @@ class TabToolbox(QtWidgets.QWidget):
             config.append(name)
             self._store_open_config(key, config)
 
-    def _remove_from_open_config(self, key):
+    def _remove_from_open_config(self, key: str) -> None:
         config = self._read_open_config(key)
         name = self.tab_toolbox_name
 
@@ -165,11 +167,11 @@ class TabToolbox(QtWidgets.QWidget):
             config.remove(name)
             self._store_open_config(key, config)
 
-    def _store_open_config(self, key, config):
+    def _store_open_config(self, key: str, config: list[str]) -> None:
         value = ",".join(config)
         Config().set(key, value)
 
-    def _get_toolbox_area_config(self):
+    def _get_toolbox_area_config(self) -> Qt.DockWidgetArea:
         result = Qt.DockWidgetArea.RightDockWidgetArea
 
         config = self._read_toolbox_area_config()
@@ -179,12 +181,12 @@ class TabToolbox(QtWidgets.QWidget):
 
         return result
 
-    def _store_toolbox_area_config(self, area):
+    def _store_toolbox_area_config(self, area: Qt.DockWidgetArea) -> None:
         config = self._read_toolbox_area_config()
         config[self.tab_toolbox_name] = area.value
         self._write_toolbox_area_config(config)
 
-    def _read_toolbox_area_config(self):
+    def _read_toolbox_area_config(self) -> dict[str, int]:
         composite_config = []
         try:
             key = self.CONF_KEY_TOOLBOX_AREAS
@@ -204,7 +206,7 @@ class TabToolbox(QtWidgets.QWidget):
 
         return config
 
-    def _write_toolbox_area_config(self, config):
+    def _write_toolbox_area_config(self, config: dict[str, int]) -> None:
         key = self.CONF_KEY_TOOLBOX_AREAS
         value = ",".join(map(lambda item: f"{item[0]}:{item[1]}", config.items()))
         Config().set(key, value)

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -30,7 +30,11 @@ Shows all the parameters available in the Crazyflie and also gives the ability
 to edit them.
 """
 
+from __future__ import annotations
+from cfclient.ui.pluginhelper import PluginHelper
+
 import logging
+from collections.abc import Iterator
 from collections import defaultdict
 from typing import Any, overload
 
@@ -45,69 +49,79 @@ from PySide6.QtCore import (
     QPersistentModelIndex,
 )
 from PySide6.QtGui import QBrush, QColor
-from PySide6.QtWidgets import QFileDialog, QHeaderView, QMessageBox
+from PySide6.QtWidgets import QFileDialog, QHeaderView, QMessageBox, QWidget
 
 import cfclient
 from cfclient.gui import create_task
 from cfclient.ui.tab_toolbox import TabToolbox
+from cflib2 import Crazyflie
+from cflib2.param import PersistentParamState, Param
+import asyncio
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from PySide6.QtWidgets import QFrame, QLabel, QLineEdit, QPushButton, QTreeView
+
 
 FILE_REGEX_YAML = "Config *.yaml;;All *.*"
 
 __author__ = "Bitcraze AB"
 __all__ = ["ParamTab"]
 
-param_tab_class = loadUiType(cfclient.module_path + "/ui/tabs/paramTab.ui")[0]  # type: ignore[index]
+if TYPE_CHECKING:
+    param_tab_class = QWidget
+else:
+    param_tab_class = loadUiType(cfclient.module_path + "/ui/tabs/paramTab.ui")[0]
 
 logger = logging.getLogger(__name__)
 
 
-def round_if_float(value):
+def round_if_float(value: int | float) -> int | float:
     """If the value is float, we limit to 5 significant numbers"""
-    try:
-        value = float(value)
-        value = f"{value:.5g}"
-    except (ValueError, TypeError):
-        pass
+    if isinstance(value, float):
+        return float(f"{value:.5g}")
     return value
 
 
 class ParamChildItem:
     """Represents a leaf-node in the tree-view (one parameter)"""
 
-    def __init__(self, parent, name):
+    def __init__(self, parent: ParamGroupItem, name: str) -> None:
         self.parent = parent
         self.name = name
-        self.ctype = None
+        self.ctype: str | None = None
         self.writable = False
         self.persistent = False
-        self.value = ""
+        self.value: int | float | None = None
         self.is_updating = True
-        self.stored_value = ""
+        self.stored_value: int | float | None = None
 
-    def child_count(self):
+    def child_count(self) -> int:
         return 0
 
 
 class ParamGroupItem:
     """Represents a parameter group in the tree-view"""
 
-    def __init__(self, name, model):
+    def __init__(self, name: str, model: ParamBlockModel) -> None:
         super().__init__()
         self.parent = None
-        self.children = []
+        self.children: list[ParamChildItem] = []
         self.name = name
         self.model = model
+        self.index: QModelIndex | None = None
 
-    def child_count(self):
+    def child_count(self) -> int:
         return len(self.children)
 
 
 class ParamBlockModel(QAbstractItemModel):
     """Model for handling the parameters in the tree-view"""
 
-    def __init__(self, parent, mainUI):
+    def __init__(self, parent: QObject | None, mainUI: QWidget) -> None:
         super().__init__(parent)
-        self._nodes = []
+        self._nodes: list[ParamGroupItem] = []
         self._column_headers = [
             "Name",
             "Type",
@@ -119,17 +133,17 @@ class ParamBlockModel(QAbstractItemModel):
         self._red_brush = QBrush(QColor("red"))
         self._enabled = False
         self._mainUI = mainUI
-        self.proxy = None
+        self.proxy: QSortFilterProxyModel | None = None
 
-    def set_proxy(self, proxy):
+    def set_proxy(self, proxy: QSortFilterProxyModel) -> None:
         self.proxy = proxy
 
-    def set_enabled(self, enabled):
+    def set_enabled(self, enabled: bool) -> None:
         if self._enabled != enabled:
             self._enabled = enabled
             self.layoutChanged.emit()
 
-    async def set_toc(self, param):
+    async def set_toc(self, param: Param) -> None:
         """Populate the model with data from the cflib2 param subsystem"""
         groups = defaultdict(list)
         for complete_name in param.names():
@@ -149,7 +163,7 @@ class ParamBlockModel(QAbstractItemModel):
 
         self.layoutChanged.emit()
 
-    def refresh(self):
+    def refresh(self) -> None:
         self.layoutChanged.emit()
 
     @overload
@@ -179,7 +193,7 @@ class ParamBlockModel(QAbstractItemModel):
         orientation: Qt.Orientation,
         /,
         role: int = Qt.ItemDataRole.DisplayRole,
-    ) -> Any:
+    ) -> str | None:
         if role == Qt.ItemDataRole.DisplayRole:
             return self._column_headers[section]
 
@@ -215,7 +229,7 @@ class ParamBlockModel(QAbstractItemModel):
         index: QModelIndex | QPersistentModelIndex,
         /,
         role: int = Qt.ItemDataRole.DisplayRole,
-    ) -> Any:
+    ) -> str | int | float | QColor | QBrush | None:
         if role == Qt.ItemDataRole.BackgroundRole:
             bgColor = self._mainUI.palette().color(self._mainUI.backgroundRole())
             if index.row() % 2 == 0:
@@ -256,7 +270,7 @@ class ParamBlockModel(QAbstractItemModel):
 
         return None
 
-    def find_node(self, group_name, param_name):
+    def find_node(self, group_name: str, param_name: str) -> ParamChildItem | None:
         """Find and return a parameter node by group and param name."""
         for group in self._nodes:
             if group.name == group_name:
@@ -265,21 +279,21 @@ class ParamBlockModel(QAbstractItemModel):
                         return node
         return None
 
-    def iter_all_nodes(self):
+    def iter_all_nodes(self) -> Iterator[tuple[str, ParamChildItem]]:
         """Yield (complete_name, node) for every parameter node."""
         for group in self._nodes:
             for node in group.children:
                 yield f"{group.name}.{node.name}", node
 
-    def notify_value_changed(self, node):
+    def notify_value_changed(self, node: ParamChildItem) -> None:
         """Refresh only column 4 (Value) for the given node."""
         self._emit_column_changed(node, 4)
 
-    def notify_stored_value_changed(self, node):
+    def notify_stored_value_changed(self, node: ParamChildItem) -> None:
         """Refresh only column 5 (Stored Value) for the given node."""
         self._emit_column_changed(node, 5)
 
-    def _emit_column_changed(self, node, col):
+    def _emit_column_changed(self, node: ParamChildItem, col: int) -> None:
         if self.proxy is None:
             return
         try:
@@ -294,13 +308,13 @@ class ParamBlockModel(QAbstractItemModel):
         if proxy_index.isValid():
             self.proxy.dataChanged.emit(proxy_index, proxy_index)
 
-    def flags(self, index):
+    def flags(self, index: QModelIndex | QPersistentModelIndex) -> Qt.ItemFlag:
         flag = super().flags(index)
         if not self._enabled:
             return Qt.ItemFlag.NoItemFlags
         return flag
 
-    def reset(self):
+    def reset(self) -> None:
         super().beginResetModel()
         self._nodes = []
         super().endResetModel()
@@ -312,7 +326,7 @@ class ParamTreeFilterProxy(QSortFilterProxyModel):
     Implement a filtering proxy model that shows all children if the group matches.
     """
 
-    def __init__(self, paramTree):
+    def __init__(self, paramTree: QWidget) -> None:
         super().__init__(paramTree)
 
     def filterAcceptsRow(
@@ -329,13 +343,33 @@ class ParamTab(TabToolbox, param_tab_class):
     them
     """
 
-    def __init__(self, helper):
+    if TYPE_CHECKING:
+        # Declared by loadUiType from paramTab.ui
+        filterBox: QLineEdit
+        paramTree: QTreeView
+        paramDetailsLabel: QLabel
+        paramDetailsDescription: QLabel
+        valueFrame: QFrame
+        currentValue: QLineEdit
+        setParamButton: QPushButton
+        resetDefaultButton: QPushButton
+        defaultValue: QLabel
+        persistentFrame: QFrame
+        storedValue: QLabel
+        persistentButton: QPushButton
+        _dump_param_button: QPushButton
+        _load_param_button: QPushButton
+        _clear_param_button: QPushButton
+
+        def setupUi(self, widget: QWidget) -> None: ...
+
+    def __init__(self, helper: PluginHelper) -> None:
         super().__init__(helper, "Parameters")
         self.setupUi(self)
 
-        self._cf = None
-        self._load_params_task = None
-        self._fetch_details_task = None
+        self._cf: Crazyflie | None = None
+        self._load_params_task: asyncio.Task[None] | None = None
+        self._fetch_details_task: asyncio.Task[None] | None = None
         self._model = ParamBlockModel(None, self._helper.mainUI)
 
         self.setParamButton.clicked.connect(self._set_param_value_clicked)
@@ -352,8 +386,8 @@ class ParamTab(TabToolbox, param_tab_class):
         self._model.set_proxy(self.proxyModel)
 
         @QtCore.Slot(str)
-        def onFilterChanged(text):
-            self.proxyModel.setFilterRegExp(text)
+        def onFilterChanged(text: str) -> None:
+            self.proxyModel.setFilterRegularExpression(text)
 
         self.filterBox.textChanged.connect(onFilterChanged)
 
@@ -372,7 +406,7 @@ class ParamTab(TabToolbox, param_tab_class):
         self._is_connected = False
         self._update_param_io_buttons()
 
-    def connected(self, cf):
+    def connected(self, cf: Crazyflie) -> None:
         self._cf = cf
         param = cf.param()
         self._model.reset()
@@ -380,7 +414,7 @@ class ParamTab(TabToolbox, param_tab_class):
         self._is_connected = True
         self._update_param_io_buttons()
 
-    def disconnected(self):
+    def disconnected(self) -> None:
         if self._load_params_task is not None:
             self._load_params_task.cancel()
             self._load_params_task = None
@@ -394,7 +428,7 @@ class ParamTab(TabToolbox, param_tab_class):
         self._paramChanged()
         self._model.set_enabled(False)
 
-    async def _load_params(self, param):
+    async def _load_params(self, param: Param) -> None:
         """Load TOC, then fetch all parameter values."""
         await self._model.set_toc(param)
         self._model.set_enabled(True)
@@ -404,30 +438,30 @@ class ParamTab(TabToolbox, param_tab_class):
             node.is_updating = False
         self._model.layoutChanged.emit()
 
-    def _set_param_value_clicked(self):
+    def _set_param_value_clicked(self) -> None:
         name = self.paramDetailsLabel.text()
-        value = self.currentValue.text()
-        create_task(self._async_set_param(name, value))
-
-    async def _async_set_param(self, name, value):
-        if self._cf is None:
-            return
-        # Convert to appropriate numeric type
+        text = self.currentValue.text()
         try:
-            numeric_value = int(value)
+            value: int | float = int(text)
         except ValueError:
             try:
-                numeric_value = float(value)
+                value = float(text)
             except ValueError:
-                logger.warning("Invalid parameter value: %s", value)
+                logger.warning("Invalid parameter value: %s", text)
                 return
-        param = self._cf.param()
-        await param.set(name, numeric_value)
+        create_task(self._async_set_param(name, value))
+
+    async def _async_set_param(self, name: str, value: int | float) -> None:
+        cf = self._cf
+        if cf is None:
+            return
+        param = cf.param()
+        await param.set(name, value)
         # Read back updated value
         new_value = await param.get(name)
         self._update_node_value(name, new_value)
 
-    def _update_node_value(self, complete_name, value):
+    def _update_node_value(self, complete_name: str, value: int | float) -> None:
         """Update a node's displayed value after a set."""
         node = self._find_node_by_complete_name(complete_name)
         if node:
@@ -435,7 +469,7 @@ class ParamTab(TabToolbox, param_tab_class):
             node.is_updating = False
             self._model.notify_value_changed(node)
 
-    def _paramChanged(self):
+    def _paramChanged(self) -> None:
         group = None
         param = None
         indexes = self.paramTree.selectionModel().selectedIndexes()
@@ -455,7 +489,7 @@ class ParamTab(TabToolbox, param_tab_class):
         self.paramDetailsLabel.setVisible(are_details_visible)
         self.paramDetailsDescription.setVisible(are_details_visible)
 
-        if param and self._cf is not None:
+        if param and group and self._cf is not None:
             complete = f"{group}.{param}"
             self.paramDetailsLabel.setText(complete)
 
@@ -473,7 +507,7 @@ class ParamTab(TabToolbox, param_tab_class):
             if node is None:
                 return
 
-            self.currentValue.setText(str(node.value))
+            self.currentValue.setText(str(node.value) if node.value is not None else "")
             self.currentValue.setStyleSheet("")
             self.currentValue.setCursorPosition(0)
             self.defaultValue.setText("-")
@@ -489,7 +523,9 @@ class ParamTab(TabToolbox, param_tab_class):
                 self._async_fetch_param_details(complete, node)
             )
 
-    async def _async_fetch_param_details(self, complete_name, node):
+    async def _async_fetch_param_details(
+        self, complete_name: str, node: ParamChildItem
+    ) -> None:
         """Fetch default value and persistent state for the selected param."""
         if self._cf is None:
             return
@@ -511,13 +547,13 @@ class ParamTab(TabToolbox, param_tab_class):
             if self._fetch_details_task is not my_task:
                 return  # A newer selection replaced us
             self._show_persistent_state(state)
-            if state.is_stored:
+            if state.is_stored and state.stored_value is not None:
                 node.stored_value = round_if_float(state.stored_value)
             else:
-                node.stored_value = ""
+                node.stored_value = None
             self._model.notify_stored_value_changed(node)
 
-    def _show_persistent_state(self, state):
+    def _show_persistent_state(self, state: PersistentParamState) -> None:
         self.persistentFrame.setVisible(True)
         if state.is_stored:
             self.storedValue.setText(str(state.stored_value))
@@ -525,11 +561,11 @@ class ParamTab(TabToolbox, param_tab_class):
             self.storedValue.setText("Not stored")
         self.persistentButton.setText("Clear" if state.is_stored else "Store")
 
-    def _persistent_button_clicked(self, _):
+    def _persistent_button_clicked(self, _: bool) -> None:
         complete = self.paramDetailsLabel.text()
         create_task(self._async_persistent_action(complete))
 
-    async def _async_persistent_action(self, complete_name):
+    async def _async_persistent_action(self, complete_name: str) -> None:
         if self._cf is None:
             return
         param = self._cf.param()
@@ -546,22 +582,22 @@ class ParamTab(TabToolbox, param_tab_class):
         # Update model node
         node = self._find_node_by_complete_name(complete_name)
         if node:
-            if state.is_stored:
+            if state.is_stored and state.stored_value is not None:
                 node.stored_value = round_if_float(state.stored_value)
             else:
-                node.stored_value = ""
+                node.stored_value = None
             self._model.notify_stored_value_changed(node)
 
-    def _find_node_by_complete_name(self, complete_name):
+    def _find_node_by_complete_name(self, complete_name: str) -> ParamChildItem | None:
         group_name, param_name = complete_name.split(".", 1)
         return self._model.find_node(group_name, param_name)
 
-    def _update_param_io_buttons(self):
+    def _update_param_io_buttons(self) -> None:
         self._load_param_button.setEnabled(self._is_connected)
         self._dump_param_button.setEnabled(self._is_connected)
         self._clear_param_button.setEnabled(self._is_connected)
 
-    def _clear_stored_persistent_params_button_clicked(self):
+    def _clear_stored_persistent_params_button_clicked(self) -> None:
         dlg = QMessageBox(self)
         dlg.setWindowTitle("Clear Stored Parameters Confirmation")
         dlg.setText("Are you sure you want to clear your stored persistent parameters?")
@@ -573,7 +609,7 @@ class ParamTab(TabToolbox, param_tab_class):
         if button == QMessageBox.StandardButton.Yes:
             create_task(self._async_clear_all_persistent())
 
-    async def _async_clear_all_persistent(self):
+    async def _async_clear_all_persistent(self) -> None:
         if self._cf is None:
             return
         param = self._cf.param()
@@ -585,10 +621,10 @@ class ParamTab(TabToolbox, param_tab_class):
                     await param.persistent_clear(complete_name)
                     node = self._find_node_by_complete_name(complete_name)
                     if node:
-                        node.stored_value = ""
+                        node.stored_value = None
                         self._model.notify_stored_value_changed(node)
 
-    def _dump_param_button_clicked(self):
+    def _dump_param_button_clicked(self) -> None:
         names = QFileDialog.getSaveFileName(
             self, "Save file", cfclient.config_path, FILE_REGEX_YAML
         )
@@ -599,7 +635,7 @@ class ParamTab(TabToolbox, param_tab_class):
             filename += ".yaml"
         create_task(self._async_dump_params(filename))
 
-    async def _async_dump_params(self, filename):
+    async def _async_dump_params(self, filename: str) -> None:
         if self._cf is None:
             return
         param = self._cf.param()
@@ -633,7 +669,7 @@ class ParamTab(TabToolbox, param_tab_class):
         dlg.setText("Dumped persistent parameters to file:\n" + "\n".join(param_lines))
         dlg.exec()
 
-    def _load_param_button_clicked(self):
+    def _load_param_button_clicked(self) -> None:
         names = QFileDialog.getOpenFileName(
             self, "Open file", cfclient.config_path, FILE_REGEX_YAML
         )
@@ -654,7 +690,7 @@ class ParamTab(TabToolbox, param_tab_class):
 
         create_task(self._async_load_params(names[0]))
 
-    async def _async_load_params(self, filename):
+    async def _async_load_params(self, filename: str) -> None:
         if self._cf is None:
             return
         try:

--- a/src/cfclient/ui/tabs/ParamTab.py
+++ b/src/cfclient/ui/tabs/ParamTab.py
@@ -55,6 +55,7 @@ import cfclient
 from cfclient.gui import create_task
 from cfclient.ui.tab_toolbox import TabToolbox
 from cflib2 import Crazyflie
+from cflib2.error import ConversionError, InvalidParameterError, ParamError
 from cflib2.param import PersistentParamState, Param
 import asyncio
 
@@ -729,15 +730,21 @@ class ParamTab(TabToolbox, param_tab_class):
                 value = entry
             try:
                 await param.set(name, value)
-                await param.persistent_store(name)
-                loaded.append(f"{name}: {value}")
-                node = self._find_node_by_complete_name(name)
-                if node:
-                    node.stored_value = round_if_float(value)
-                    self._model.notify_stored_value_changed(node)
-            except Exception:
-                logger.warning("Failed to set %s", name)
+            except (ParamError, ConversionError, InvalidParameterError) as e:
+                logger.warning("Failed to set %s: %s", name, e)
                 failed.append(name)
+                continue
+
+            try:
+                await param.persistent_store(name)
+            except ParamError as e:
+                logger.warning("Failed to store %s: %s", name, e)
+
+            loaded.append(f"{name}: {value}")
+            node = self._find_node_by_complete_name(name)
+            if node:
+                node.stored_value = round_if_float(value)
+                self._model.notify_stored_value_changed(node)
 
         message = "Loaded persistent parameters from file:\n" + "\n".join(loaded)
         if failed:


### PR DESCRIPTION
Enable ruff's ANN lint rules to enforce type annotations going forward, catch bugs earlier and improving code readability, and allowing the type checker (e.g. ty) to show types and warn about issues in your IDE. This PR adds type to gui.py, main.py, tab_toolbox.py, and ParamTab.py to comply with new rules. It also fixes various type errors flagged by ty, though full ty compat is not done yet. 

ruff ANN is not enforced by CI yet; now this relies on contributors installing pre-commit locally. ty isn't even enabled in pre-commit yet and relies on the user running it manually / installing to their IDE.

Also bumps the cflib2 pin.