### PR TITLE
Increase pose log rate from 25Hz to 60Hz

### DIFF
--- a/src/cfclient/ui/pose_logger.py
+++ b/src/cfclient/ui/pose_logger.py
@@ -103,7 +103,7 @@ class PoseLogger:
         await block.add_variable(self.LOG_NAME_ESTIMATE_PITCH)
         await block.add_variable(self.LOG_NAME_ESTIMATE_YAW)
 
-        stream = await block.start(40)  # 40ms period
+        stream = await block.start(16)  # 16ms period
         try:
             while True:
                 data = await stream.next()


### PR DESCRIPTION
Increases the PoseLogger telemetry rate from 40ms to 16ms, bringing the attitude indicator from ~25fps to ~60fps. The difference in smoothness is very noticeable. Trades some extra radio bandwidth for a much nicer visual experience, worth considering if that's an acceptable tradeoff.