### PR TITLE
Catch DisconnectedError in create_task wrapper instead of per-coroutine

### DIFF
--- a/src/cfclient/gui.py
+++ b/src/cfclient/gui.py
@@ -68,13 +68,18 @@ def _task_done_callback(task: asyncio.Task[object]) -> None:
         return
     try:
         task.result()
-    except DisconnectedError:
-        logger.debug("Task interrupted by disconnect: %s", task)
     except Exception:
         import traceback
 
         traceback.print_exc()
         os._exit(1)
+
+
+async def _wrap_disconnected(coro: Coroutine[object, object, object]) -> None:
+    try:
+        await coro
+    except DisconnectedError:
+        logger.debug("Task interrupted by disconnect")
 
 
 def create_task(coro: Coroutine[object, object, object]) -> asyncio.Task[object]:
@@ -84,7 +89,7 @@ def create_task(coro: Coroutine[object, object, object]) -> asyncio.Task[object]
     are logged immediately rather than silently swallowed.
     """
     logger.debug(f"create_task: {coro}")
-    task = asyncio.ensure_future(coro)
+    task = asyncio.ensure_future(_wrap_disconnected(coro))
     task.add_done_callback(_task_done_callback)
     return task
 

--- a/src/cfclient/gui.py
+++ b/src/cfclient/gui.py
@@ -79,7 +79,7 @@ async def _wrap_disconnected(coro: Coroutine[object, object, object]) -> None:
     try:
         await coro
     except DisconnectedError:
-        logger.debug("Task interrupted by disconnect")
+        logger.debug("Task interrupted by disconnect: %r", coro)
 
 
 def create_task(coro: Coroutine[object, object, object]) -> asyncio.Task[object]:

--- a/src/cfclient/gui.py
+++ b/src/cfclient/gui.py
@@ -86,7 +86,8 @@ def create_task(coro: Coroutine[object, object, object]) -> asyncio.Task[object]
     """Schedule a coroutine as a task with automatic exception logging.
 
     Use this instead of asyncio.ensure_future() to ensure exceptions
-    are logged immediately rather than silently swallowed.
+    are logged immediately rather than silently swallowed. DisconnectedError
+    is treated as a normal shutdown case and is logged at debug level only.
     """
     logger.debug(f"create_task: {coro}")
     task = asyncio.ensure_future(_wrap_disconnected(coro))

--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -616,8 +616,6 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
                 self._battery_signal.emit(
                     data.data["pm.vbat"], int(data.data["pm.state"])
                 )
-        except DisconnectedError:
-            pass
         finally:
             if stream is not None:
                 try:

--- a/src/cfclient/ui/pose_logger.py
+++ b/src/cfclient/ui/pose_logger.py
@@ -120,8 +120,6 @@ class PoseLogger:
                     data.data[self.LOG_NAME_ESTIMATE_YAW],
                 )
                 self.data_received_cb.call(self, self.pose)
-        except DisconnectedError:
-            pass
         finally:
             if stream is not None:
                 try:

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -564,8 +564,6 @@ class FlightTab(TabToolbox, flight_tab_class):
             while True:
                 data = await stream.next()
                 self._log_data_received(data.timestamp, data.data)
-        except DisconnectedError:
-            pass
         finally:
             if stream is not None:
                 try:


### PR DESCRIPTION
The existing `_task_done_callback` was meant to catch `DisconnectedError` for all tasks created via `create_task`, but PySide6's QtAsyncio logs unhandled task exceptions before done callbacks run. So the callback did catch the error (preventing `os._exit`), but the traceback was already printed. By wrapping the coroutine inside `create_task`, the exception is caught before it ever leaves the coroutine, so PySide6 never sees it. This also removes the now-redundant per-coroutine `except DisconnectedError: pass` blocks and the dead `except DisconnectedError` from `_task_done_callback`.