### PR TITLE
Guard log stream setup against missing TOC variables

### DIFF
--- a/src/cfclient/ui/main.py
+++ b/src/cfclient/ui/main.py
@@ -592,15 +592,22 @@ class MainUI(QtWidgets.QMainWindow, main_window_class):
     async def _stream_battery(self, cf):
         log = cf.log()
         block = await log.create_block()
-        await block.add_variable("pm.vbat")
-        await block.add_variable("pm.state")
+
+        available = log.names()
+        for name in ("pm.vbat", "pm.state"):
+            if name in available:
+                await block.add_variable(name)
+            else:
+                logger.warning("Log variable %s missing from TOC, skipping", name)
+
         stream = await block.start(1000)
         try:
             while True:
                 data = await stream.next()
-                self._battery_signal.emit(
-                    data.data["pm.vbat"], int(data.data["pm.state"])
-                )
+                if "pm.vbat" in data.data and "pm.state" in data.data:
+                    self._battery_signal.emit(
+                        data.data["pm.vbat"], int(data.data["pm.state"])
+                    )
         finally:
             try:
                 await asyncio.shield(stream.stop())

--- a/src/cfclient/ui/pose_logger.py
+++ b/src/cfclient/ui/pose_logger.py
@@ -96,24 +96,32 @@ class PoseLogger:
     async def _stream_loop(self, cf):
         log = cf.log()
         block = await log.create_block()
-        await block.add_variable(self.LOG_NAME_ESTIMATE_X)
-        await block.add_variable(self.LOG_NAME_ESTIMATE_Y)
-        await block.add_variable(self.LOG_NAME_ESTIMATE_Z)
-        await block.add_variable(self.LOG_NAME_ESTIMATE_ROLL)
-        await block.add_variable(self.LOG_NAME_ESTIMATE_PITCH)
-        await block.add_variable(self.LOG_NAME_ESTIMATE_YAW)
+
+        available = log.names()
+        for name in (
+            self.LOG_NAME_ESTIMATE_X,
+            self.LOG_NAME_ESTIMATE_Y,
+            self.LOG_NAME_ESTIMATE_Z,
+            self.LOG_NAME_ESTIMATE_ROLL,
+            self.LOG_NAME_ESTIMATE_PITCH,
+            self.LOG_NAME_ESTIMATE_YAW,
+        ):
+            if name in available:
+                await block.add_variable(name)
+            else:
+                logger.warning("Log variable %s missing from TOC, skipping", name)
 
         stream = await block.start(16)  # 16ms period
         try:
             while True:
                 data = await stream.next()
                 self.pose = (
-                    data.data[self.LOG_NAME_ESTIMATE_X],
-                    data.data[self.LOG_NAME_ESTIMATE_Y],
-                    data.data[self.LOG_NAME_ESTIMATE_Z],
-                    data.data[self.LOG_NAME_ESTIMATE_ROLL],
-                    data.data[self.LOG_NAME_ESTIMATE_PITCH],
-                    data.data[self.LOG_NAME_ESTIMATE_YAW],
+                    data.data.get(self.LOG_NAME_ESTIMATE_X, 0.0),
+                    data.data.get(self.LOG_NAME_ESTIMATE_Y, 0.0),
+                    data.data.get(self.LOG_NAME_ESTIMATE_Z, 0.0),
+                    data.data.get(self.LOG_NAME_ESTIMATE_ROLL, 0.0),
+                    data.data.get(self.LOG_NAME_ESTIMATE_PITCH, 0.0),
+                    data.data.get(self.LOG_NAME_ESTIMATE_YAW, 0.0),
                 )
                 self.data_received_cb.call(self, self.pose)
         finally:

--- a/src/cfclient/ui/tabs/FlightTab.py
+++ b/src/cfclient/ui/tabs/FlightTab.py
@@ -345,19 +345,25 @@ class FlightTab(TabToolbox, flight_tab_class):
 
     def _log_data_received(self, timestamp, data):
         if self.isVisible() and self._isConnected:
-            self.actualM1.setValue(data[self.LOG_NAME_MOTOR_1])
-            self.actualM2.setValue(data[self.LOG_NAME_MOTOR_2])
-            self.actualM3.setValue(data[self.LOG_NAME_MOTOR_3])
-            self.actualM4.setValue(data[self.LOG_NAME_MOTOR_4])
+            if self.LOG_NAME_MOTOR_1 in data:
+                self.actualM1.setValue(data[self.LOG_NAME_MOTOR_1])
+            if self.LOG_NAME_MOTOR_2 in data:
+                self.actualM2.setValue(data[self.LOG_NAME_MOTOR_2])
+            if self.LOG_NAME_MOTOR_3 in data:
+                self.actualM3.setValue(data[self.LOG_NAME_MOTOR_3])
+            if self.LOG_NAME_MOTOR_4 in data:
+                self.actualM4.setValue(data[self.LOG_NAME_MOTOR_4])
 
-            self.estimateThrust.setText(
-                "%.2f%%" % self.thrustToPercentage(data[self.LOG_NAME_THRUST])
-            )
+            if self.LOG_NAME_THRUST in data:
+                self.estimateThrust.setText(
+                    "%.2f%%" % self.thrustToPercentage(data[self.LOG_NAME_THRUST])
+                )
 
-            if data[self.LOG_NAME_CAN_FLY] != self._can_fly_deprecated:
-                self._can_fly_deprecated = data[self.LOG_NAME_CAN_FLY]
-                if self._cf is not None:
-                    create_task(self._update_flight_commander(self._cf))
+            if self.LOG_NAME_CAN_FLY in data:
+                if data[self.LOG_NAME_CAN_FLY] != self._can_fly_deprecated:
+                    self._can_fly_deprecated = data[self.LOG_NAME_CAN_FLY]
+                    if self._cf is not None:
+                        create_task(self._update_flight_commander(self._cf))
 
             if self.LOG_NAME_SUPERVISOR_INFO in data:
                 self._supervisor_info_bitfield = data[self.LOG_NAME_SUPERVISOR_INFO]
@@ -534,15 +540,21 @@ class FlightTab(TabToolbox, flight_tab_class):
     async def _stream_motors(self, cf):
         log = cf.log()
         block = await log.create_block()
-        await block.add_variable(self.LOG_NAME_THRUST)
-        await block.add_variable(self.LOG_NAME_MOTOR_1)
-        await block.add_variable(self.LOG_NAME_MOTOR_2)
-        await block.add_variable(self.LOG_NAME_MOTOR_3)
-        await block.add_variable(self.LOG_NAME_MOTOR_4)
-        await block.add_variable(self.LOG_NAME_CAN_FLY)
 
-        if self.LOG_NAME_SUPERVISOR_INFO in log.names():
-            await block.add_variable(self.LOG_NAME_SUPERVISOR_INFO)
+        available = log.names()
+        for name in (
+            self.LOG_NAME_THRUST,
+            self.LOG_NAME_MOTOR_1,
+            self.LOG_NAME_MOTOR_2,
+            self.LOG_NAME_MOTOR_3,
+            self.LOG_NAME_MOTOR_4,
+            self.LOG_NAME_CAN_FLY,
+            self.LOG_NAME_SUPERVISOR_INFO,
+        ):
+            if name in available:
+                await block.add_variable(name)
+            else:
+                logger.warning("Log variable %s missing from TOC, skipping", name)
 
         period_ms = Config().get("ui_update_period")
         stream = await block.start(period_ms)


### PR DESCRIPTION
Fixes #800.

Wraps the three async `block.add_variable()` setup sites flagged in the issue with `log.names()` presence checks, mirroring the existing `supervisor.info` guard in `_stream_motors`. When a variable is missing from the firmware log TOC, it is skipped with a warning rather than raising inside the `create_task()` coroutine.

### Per-file changes

- **`src/cfclient/ui/tabs/FlightTab.py` (`_stream_motors`)** — guards `stabilizer.thrust`, `motor.m1`–`m4`, `sys.canfly`, and `supervisor.info` (existing guard folded into the new loop). `_log_data_received` now checks key presence before reading each motor / thrust / can-fly value, matching the pattern already used for `supervisor.info`.
- **`src/cfclient/ui/main.py` (`_stream_battery`)** — guards `pm.vbat` and `pm.state`. The stream loop only emits `_battery_signal` when both keys are present in the sample.
- **`src/cfclient/ui/pose_logger.py` (`_stream_loop`)** — guards all six `stateEstimate.*` variables. The consumer uses `data.data.get(name, 0.0)` so missing axes fall back to the existing `NO_POSE` default value rather than raising.

### Notes on scope

The issue lists three specific async setup sites; this PR only touches those. There are other `add_variable()` callers in the codebase that use the older synchronous log-config API (e.g. `GpsTab.py`, `ColorLEDTab.py`, `lighthouse_tab.py`, `locopositioning_tab.py`, `cfzmq/__init__.py`) — different surface, different failure mode, left alone to keep the diff surgical. Happy to follow up in a separate PR if a similar guard is wanted there.

No new tests: there is no pytest harness wired into the cflib2 CI yet, and these UI-coupled async streams would need a non-trivial mock setup. The guards are conservative — they only short-circuit when a name is absent from `log.names()`, otherwise behavior is unchanged.