### PR TITLE
Fixed eglSwapBuffers warning for Loco tab

### DIFF
--- a/src/cfclient/ui/tabs/locopositioning_tab.py
+++ b/src/cfclient/ui/tabs/locopositioning_tab.py
@@ -124,7 +124,10 @@ class Plot3dLps(scene.SceneCanvas):
     TEXT_OFFSET = np.array((0.0, 0, 0.25))
 
     def __init__(self):
-        scene.SceneCanvas.__init__(self, keys=None)
+        # Note: autoswap is disabled since Qt's QOpenGLWidget path already presents
+        # the FBO; enabling vispy autoswap here would cause a redundant swap and
+        # eglSwapBuffers warnings.
+        scene.SceneCanvas.__init__(self, keys=None, autoswap=False)
         self.unfreeze()
 
         self._view = self.central_widget.add_view()


### PR DESCRIPTION
This PR fixes the repeated `eglSwapBuffers failed with 0x300d` warnings when opening the Loco Positioning tab by preventing vispy from performing an extra buffer swap that Qt already handles when embedding the canvas.

it is identical to #796.